### PR TITLE
Navigation to source file

### DIFF
--- a/TexSoup/__init__.py
+++ b/TexSoup/__init__.py
@@ -73,4 +73,5 @@ def TexSoup(tex):
     >>> ''.join(str(soup).splitlines())
     'SOUP'
     """
-    return TexNode(read(tex))
+    parsed, src = read(tex)
+    return TexNode(parsed, src=src)

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -13,7 +13,9 @@ ARG_END_TOKENS = {arg.delims()[1] for arg in data.args}
 ARG_TOKENS = ARG_START_TOKENS | ARG_END_TOKENS
 ALL_TOKENS = COMMAND_TOKENS | ARG_TOKENS | MATH_TOKENS
 SKIP_ENVS = ('verbatim', 'equation', 'lstlisting')
-PUNCTUATION_COMMANDS = ('right', 'left')
+PUNCTUATION_COMMANDS = {command + bracket
+                        for command in ('left', 'right')
+                        for bracket in r'( ) < > \[ ] [ { \{ \} . |'.split(' ') }
 
 
 #############
@@ -100,7 +102,7 @@ def tokenize_punctuation_command(text):
     if text.peek() == '\\':
         for string in PUNCTUATION_COMMANDS:
             if text.peek((1, len(string) + 1)) == string:
-                return text.forward(len(string) + 3)
+                return text.forward(len(string) + 1)
 
 
 @token('command')

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -1,4 +1,4 @@
-from TexSoup.utils import to_buffer, Buffer
+from TexSoup.utils import to_buffer, Buffer, TokenWithPosition
 from TexSoup.data import *
 import TexSoup.data as data
 import functools
@@ -45,10 +45,11 @@ def next_token(text):
     >>> next_token(b)
     """
     while text.hasNext():
+        cur_pos = text.position()
         for name, f in tokenizers:
             token = f(text)
             if token is not None:
-                return token
+                return TokenWithPosition(token, cur_pos)
 
 
 @to_buffer

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -136,7 +136,6 @@ def tokenize_math(text):
     >>> tokenize_math(b)
     '$$\\min_x$$'
     """
-#     result = ''
     result = TokenWithPosition('', text.position)
     if text.startswith('$'):
         starter = '$$' if text.startswith('$$') else '$'
@@ -166,7 +165,6 @@ def tokenize_string(text, delimiters=ALL_TOKENS):
     >>> print(tokenize_string(Buffer('0 & 1 \\\\\command')))
     0 & 1 \\
     """
-#     result = ''
     result = TokenWithPosition('', text.position)
     for c in text:
         if c == '\\' and str(text.peek()) in delimiters:

--- a/TexSoup/tex.py
+++ b/TexSoup/tex.py
@@ -13,10 +13,10 @@ def read(tex):
     if isinstance(tex, str):
         tex = tex.strip()
     else:
-        tex = itertools.chain(*tex)
+        tex = ''.join(itertools.chain(*tex))
     buf, children = Buffer(tokenize(tex)), []
     while buf.hasNext():
         content = read_tex(buf)
         if content is not None:
             children.append(content)
-    return TexEnv('[tex]', children)
+    return TexEnv('[tex]', children), tex

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -183,3 +183,27 @@ class Buffer:
 
     def __iter__(self):
         return self
+
+    def position(self):
+        return self.__i
+
+
+class TokenWithPosition(object):
+    def __init__(self, text, position):
+        self.text = text
+        self.position = position
+
+    def __repr__(self):
+        return repr(self.text)
+    
+    def __str__(self):
+        return str(self.text)
+
+    def __getattr__(self, name, default=None):
+        return getattr(self.text, name, default=default)
+
+    def __eq__(self, other):
+        if isinstance(other, TokenWithPosition):
+            return self.text == other.text
+        else:
+            return self.text == other

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -9,7 +9,7 @@ function:
 2. Generalized utilities
 """
 
-import functools
+import functools, bisect
 
 ##############
 # Decorators #
@@ -50,6 +50,110 @@ def to_buffer(f, i=0):
 #########################
 
 
+class TokenWithPosition(object):
+    def __init__(self, text, position):
+        if isinstance(text, TokenWithPosition):
+            self.text, self.position = text.text, text.position
+        else:
+            self.text = text
+            self.position = position
+
+    def __repr__(self):
+#         return '{}:{}'.format(self.position, repr(self.text))
+        return repr(self.text)
+
+    def __str__(self):
+        return str(self.text)
+
+    def __getattr__(self, name):
+        return getattr(self.text, name)
+
+    def __eq__(self, other):
+        if isinstance(other, TokenWithPosition):
+            return self.text == other.text
+        else:
+            return self.text == other
+
+    def __hash__(self):
+        return hash(self.text)
+
+    def __add__(self, other):
+        if isinstance(other, TokenWithPosition):
+            return TokenWithPosition(self.text + other.text,
+                                     self.position)
+        else:
+            return TokenWithPosition(self.text + other,
+                                     self.position)
+
+    def __radd__(self, other):
+        if isinstance(other, TokenWithPosition):
+            return TokenWithPosition(other.text + self.text,
+                                     other.position)
+        else:
+            return TokenWithPosition(other + self.text,
+                                     self.position - len(other))
+
+    def __iadd__(self, other):
+        if isinstance(other, TokenWithPosition):
+            self.text += other.text
+        else:
+            self.text += other
+        return self
+
+    @classmethod
+    def join(cls, tokens, glue=''):
+        if len(tokens) > 0:
+            return TokenWithPosition(glue.join(t.text for t in tokens),
+                                     tokens[0].position)
+        else:
+            return ''
+
+    def __bool__(self):
+        return bool(self.text)
+
+    def __contains__(self, item):
+        if isinstance(item, TokenWithPosition):
+            return item.text in self.text
+        return item in self.text
+
+    def __iter__(self):
+        return iter(self.__iter())
+
+    def __iter(self):
+        for i, c in enumerate(self.text):
+            yield TokenWithPosition(c, self.position + i)
+
+    def __getitem__(self, i):
+        if isinstance(i, int):
+            start = i
+        else:
+            start = i.start
+        if start is None:
+            start = 0
+        if start < 0:
+            start = len(self.text) + start
+        return TokenWithPosition(self.text[i], self.position + start)
+
+    def split(self, sep=None, maxsplit=-1):
+        result = []
+        split_res = self.text.split(sep=sep, maxsplit=maxsplit)
+        txt = self.text
+        cur_offset = 0
+        for s in split_res:
+            cur_offset = txt.find(s, cur_offset)
+            result.append(TokenWithPosition(s, self.position + cur_offset))
+        return result
+
+    def strip(self, *args, **kwargs):
+        stripped = self.text.strip()
+        offset = self.text.find(stripped)
+        return TokenWithPosition(stripped, self.position + offset)
+
+
+def identity(x):
+    return x
+
+
 class Buffer:
     """Converts string or iterable into a navigable iterator of strings
 
@@ -76,24 +180,21 @@ class Buffer:
     True
     >>> b1[2:4]
     '23'
-    >>> b2 = Buffer(naturals(0), coerce=int)
-    >>> b2.forward(3)
-    12
     >>> Buffer('asdf')[:10]
     'asdf'
     """
 
-    def __init__(self, iterator, coerce=str):
+    def __init__(self, iterator, join=TokenWithPosition.join):
         """Initialization for Buffer
 
         :param iterator: iterator or iterable
-        :param func coerce: optional coercion to datatype (cannot be changed)
+        :param func join: function to join multiple buffer elements
         """
         assert hasattr(iterator, '__iter__'), 'Must be an iterable.'
         self.__iterator = iter(iterator)
         self.__queue = []
         self.__i = 0
-        self.__coerce = coerce
+        self.__join = join
 
     def hasNext(self):
         """Returns whether or not there is another element."""
@@ -149,7 +250,8 @@ class Buffer:
     def __next__(self):
         """Implements next."""
         while self.__i >= len(self.__queue):
-            self.__queue.append(self.__coerce(next(self.__iterator)))
+            self.__queue.append(TokenWithPosition(next(self.__iterator), self.__i))
+#             self.__queue.append(next(self.__iterator))
         self.__i += 1
         return self.__queue[self.__i-1]
 
@@ -179,31 +281,37 @@ class Buffer:
             except StopIteration:
                 break
         self.__i = old
-        return self.__coerce(''.join(map(str, self.__queue[i])))
+        if isinstance(i, int):
+            return self.__queue[i]
+#         return ''.join(self.__queue[i])
+        return self.__join(self.__queue[i])
 
     def __iter__(self):
         return self
 
+    @property
     def position(self):
         return self.__i
 
 
-class TokenWithPosition(object):
-    def __init__(self, text, position):
-        self.text = text
-        self.position = position
+class CharToLineOffset(object):
+    '''
+    Utility to convert absolute position in the source file
+    to line_no:char_no_in_line.
+    This can be very useful if we want to parse LaTeX and
+    navigate to some elements in the generated DVI/PDF via SyncTeX.
+    '''
+    def __init__(self, src):
+        self.line_break_positions = [i for i, c in enumerate(src) if c == '\n']
+        self.src_len = len(src)
 
-    def __repr__(self):
-        return repr(self.text)
-    
-    def __str__(self):
-        return str(self.text)
-
-    def __getattr__(self, name, default=None):
-        return getattr(self.text, name, default=default)
-
-    def __eq__(self, other):
-        if isinstance(other, TokenWithPosition):
-            return self.text == other.text
+    def __call__(self, char_pos):
+        line_no = bisect.bisect(self.line_break_positions, char_pos)
+        if line_no == 0:
+            char_no = char_pos
+        elif line_no == len(self.line_break_positions):
+            line_start = self.line_break_positions[-1]
+            char_no = min(char_pos - line_start - 1, self.src_len - line_start)
         else:
-            return self.text == other
+            char_no = char_pos - self.line_break_positions[line_no - 1] - 1
+        return line_no, char_no

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -251,7 +251,6 @@ class Buffer:
         """Implements next."""
         while self.__i >= len(self.__queue):
             self.__queue.append(TokenWithPosition(next(self.__iterator), self.__i))
-#             self.__queue.append(next(self.__iterator))
         self.__i += 1
         return self.__queue[self.__i-1]
 
@@ -283,7 +282,6 @@ class Buffer:
         self.__i = old
         if isinstance(i, int):
             return self.__queue[i]
-#         return ''.join(self.__queue[i])
         return self.__join(self.__queue[i])
 
     def __iter__(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from config import *
+from TexSoup.utils import TokenWithPosition
 
 ##############
 # NAVIGATION #
@@ -30,6 +31,26 @@ def test_navigation_descendants(chikin):
     """Test identification of all descendants"""
     print(list(chikin.descendants))
     assert len(list(chikin.descendants)) == 28
+
+
+def test_navigation_positions(chikin):
+    assert chikin.char_pos_to_line(0) == (0, 0), '\\'
+    assert chikin.char_pos_to_line(1) == (0, 1), 'documentclass'
+    assert chikin.char_pos_to_line(172) == (11, 6), 'waddle'
+
+    assert isinstance(next(next(chikin.itemize.children).tokens), TokenWithPosition)
+
+    # get position of first token
+    waddle_pos = next(next(chikin.itemize.children).tokens).position
+    assert chikin.char_pos_to_line(waddle_pos) == (11, 6)
+
+    # get position of item
+    enumerate_first_item_pos = next(chikin.enumerate.children).name.position
+    assert chikin.char_pos_to_line(enumerate_first_item_pos) == (22, 1)
+
+    # get position of section
+    section_pos = list(chikin.find_all('section'))[1].name.position
+    assert chikin.char_pos_to_line(section_pos) == (15, 1)
 
 ##########
 # SEARCH #


### PR DESCRIPTION
Hi!

I was searching for a tool to parse LaTeX, extract some valuable information and then highlight it in the PDF using SyncTeX. To do this, SyncTeX requires line_no:char_no information. I decided to modify your parser to provide such information. Now each token and command name has field "position", which contains the absolute position of its first character in the source file. This absolute position can be converted to line_no:char_no using TexNode.char_pos_to_line function. For more examples, please refer to https://github.com/windj007/TexSoup/blob/master/tests/test_api.py#L36

If you find such functionality useful, please take a look at my changes.

The main idea: everywhere starting from tokenization use not just plain python strings, but strings with offsets. String operations such as concatenation, join, split, strip, indexing etc. are mimicked so they maintain these offsets.

All the available tests are passed. One more test was added test_api.py:test_navigation_positions.