### PR TITLE
Fix presence of '\$' in '$'-delimited inline math 

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -136,11 +136,19 @@ def tokenize_math(text):
     >>> tokenize_math(b)
     '$$\\min_x$$'
     """
+
+    def escaped_dollar():
+        return text.peek() == '$' and result[-1] == '\\'
+
+    def end_detected():
+        return (text.peek((0, len(starter))) == starter
+                and not escaped_dollar())
+
     result = TokenWithPosition('', text.position)
     if text.startswith('$'):
         starter = '$$' if text.startswith('$$') else '$'
         result += text.forward(len(starter))
-        while text.hasNext() and text.peek((0, len(starter))) != starter:
+        while text.hasNext() and not end_detected():
             result += next(text)
         if not text.startswith(starter):
             raise EOFError('Expecting %s. Instead got %s' % (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -216,6 +216,13 @@ def test_math_environment_whitespace():
     assert '\$' in contents[1], 'Dollar sign not escaped!'
 
 
+def test_math_environment_escape():
+    """Tests $ escapes in math environment."""
+    soup = TexSoup("$ \$ $")
+    contents = list(soup.contents)
+    assert '\$' in contents[0][0], 'Dollar sign not escaped!'
+
+
 def test_punctuation_command_structure():
     """Tests that commands for punctuation work."""
     soup = TexSoup(r"""\right. \right[ \right( \right|""")


### PR DESCRIPTION
Partially fixes #7.

When tokenizing inline math, the `\$` sequence was interpreted as the end of the inline math.