### PR TITLE
Fix multiline args

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -238,8 +238,16 @@ def read_tex(src):
         candidate_index = src.num_forward_until(lambda s: not s.isspace())
         src.forward(candidate_index)
 
-        while src.peek() in ARG_START_TOKENS:
-            expr.args.append(read_tex(src))
+        line_breaks = 0
+        while (src.peek() in ARG_START_TOKENS or (src.peek() == '\\n')
+                and line_breaks == 0):
+            if src.peek() == '\\n':
+                # Advance buffer if first newline
+                line_breaks += 1
+                next(src)
+            else:
+                line_breaks = 0
+                expr.args.append(read_tex(src))
         if not expr.args:
             src.backward(candidate_index)
         if mode == 'begin':

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -233,15 +233,14 @@ def read_tex(src):
         else:
             mode, expr = 'command', TexCmd(command)
 
-        # TODO: allow only one line break
         # TODO: should really be handled by tokenizer
         candidate_index = src.num_forward_until(lambda s: not s.isspace())
         src.forward(candidate_index)
 
         line_breaks = 0
-        while (src.peek() in ARG_START_TOKENS or (src.peek() == '\\n')
+        while (src.peek() in ARG_START_TOKENS or (src.peek() == '\n')
                 and line_breaks == 0):
-            if src.peek() == '\\n':
+            if src.peek() == '\n':
                 # Advance buffer if first newline
                 line_breaks += 1
                 next(src)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -239,6 +239,18 @@ def test_comment_unparsed():
     soup = TexSoup(r"""\caption{30} % \caption{...""")
     assert '%' not in str(soup.caption)
 
+
+def test_multiline_args():
+    """Tests that macros with arguments are different lines are parsed
+    properly."""
+    soup = TexSoup(r"""\mytitle{Essay title}\n{Essay subheading.}""")
+    assert "Essay subheading." in soup.mytitle.args
+    # Only one newline allowed
+    soup = TexSoup(r"""\mytitle{Essay title}\n\n{Essay subheading.}""")
+    assert "Essay subheading." not in soup.mytitle.args
+    assert "Essay title" in soup.mytitle.args
+
+
 ##############
 # FORMATTING #
 ##############

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -242,11 +242,14 @@ def test_comment_unparsed():
 
 def test_multiline_args():
     """Tests that macros with arguments are different lines are parsed
-    properly."""
-    soup = TexSoup(r"""\mytitle{Essay title}\n{Essay subheading.}""")
+    properly. See Issue #31."""
+    soup = TexSoup(r"""\mytitle{Essay title}
+{Essay subheading.}""")
     assert "Essay subheading." in soup.mytitle.args
     # Only one newline allowed
-    soup = TexSoup(r"""\mytitle{Essay title}\n\n{Essay subheading.}""")
+    soup = TexSoup(r"""\mytitle{Essay title}
+
+{Essay subheading.}""")
     assert "Essay subheading." not in soup.mytitle.args
     assert "Essay title" in soup.mytitle.args
 


### PR DESCRIPTION
Fixes #31 

Now macros with arguments on different lines are correctly parsed.