### PR TITLE
Added a text function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# IDEs
+.vscode

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -117,6 +117,14 @@ class TexNode(object):
         """Returns all descendants for this TeX element."""
         return self.__descendants()
 
+    @property
+    def text(self):
+        for descendant in self.contents:
+            if isinstance(descendant, TokenWithPosition):
+                yield descendant
+            elif hasattr(descendant,'text'):
+                yield from descendant.text
+
     def __descendants(self):
         """Implementation for descendants, hacky workaround for __getattr__
         issues.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,3 +106,13 @@ def test_add_children_at(chikin):
     chikin.add_children_at(0, 'asdfghjkl')
     assert 'asdfghjkl' in str(chikin)
     assert str(chikin[0]) == 'asdfghjkl'
+
+#########
+# TEXT #
+########
+def test_text(chikin):
+    """Get text of document"""
+    text = list(chikin.text)
+    assert 'Chikin Tales' in text
+    assert 'Chikin Fly' in text
+    assert 'waddle\n' in text


### PR DESCRIPTION
Adds a function to `TexNode` to return the plain text of the node. This effectively means all `TokenWithPosition` object in it's decedents tree.

This function would be useful for anyone who cares about both the structure and content of the document. Personally, I'm trying to write a TeX linter, and so I need the document tree for testing structure and `text` for testing spelling and content.

Let me know what you think. I'm happy to make any changes.