### PR TITLE
Added a regex search function to TexNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# IDEs
+.vscode

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -117,6 +117,14 @@ class TexNode(object):
         """Returns all descendants for this TeX element."""
         return self.__descendants()
 
+    @property
+    def text(self):
+        for descendant in self.contents:
+            if isinstance(descendant, TokenWithPosition):
+                yield descendant
+            elif hasattr(descendant,'text'):
+                yield from descendant.text
+
     def __descendants(self):
         """Implementation for descendants, hacky workaround for __getattr__
         issues.

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -6,6 +6,7 @@ Includes the data structures that users will interface with, in addition to
 internally used data structures.
 """
 import itertools
+import re
 from .utils import TokenWithPosition, CharToLineOffset
 
 __all__ = ['TexNode', 'TexCmd', 'TexEnv', 'Arg', 'OArg', 'RArg', 'TexArgs']
@@ -145,6 +146,13 @@ class TexNode(object):
             return next(self.find_all(name, **attrs))
         except StopIteration:
             return None
+
+    def search_regex(self, pattern):
+        for node in self.text:
+            for match in re.finditer(pattern, node):
+                body = match.group()   #group() returns the full match
+                start = match.start()
+                yield TokenWithPosition(body, node.position + start)
 
     def count(self, name=None, **attrs):
         """Return number of descendants matching criteria"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,3 +106,13 @@ def test_add_children_at(chikin):
     chikin.add_children_at(0, 'asdfghjkl')
     assert 'asdfghjkl' in str(chikin)
     assert str(chikin[0]) == 'asdfghjkl'
+
+#########
+# TEXT #
+########
+def test_text(chikin):
+    """Get text of document"""
+    text = list(chikin.text)
+    assert 'Chikin Tales' in text
+    assert 'Chikin Fly' in text
+    assert 'waddle\n' in text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from .config import *
 from TexSoup.utils import TokenWithPosition
+import re
 
 ##############
 # NAVIGATION #
@@ -116,3 +117,18 @@ def test_text(chikin):
     assert 'Chikin Tales' in text
     assert 'Chikin Fly' in text
     assert 'waddle\n' in text
+
+def test_search_regex(chikin):
+    """Find all occurenses of a regex in the document text"""
+    matches = list(chikin.search_regex(r"unless[a-z ]*"))
+    assert len(matches) == 1
+    assert matches[0] == "unless ordered to squat"
+    assert matches[0].position == 341
+
+def test_search_regex_precompiled_pattern(chikin):
+    """Find all occurenses of a regex in the document text"""
+    pattern = re.compile(r"unless[a-z ]*")
+    matches = list(chikin.search_regex(pattern))
+    assert len(matches) == 1
+    assert matches[0] == "unless ordered to squat"
+    assert matches[0].position == 341


### PR DESCRIPTION
Allows the user to search the plain text of a node with a regex. Returns a TokenWithPosition for each match.