### PR TITLE
Added \( ... \) math environment and \[ ... \] display math environment

### DIFF
--- a/TexSoup/__init__.py
+++ b/TexSoup/__init__.py
@@ -11,6 +11,7 @@ Main file, containing most commonly used elements of TexSoup
 from TexSoup.tex import *
 
 
+# noinspection PyPep8Naming
 def TexSoup(tex):
     r"""
     At a high-level, parses provided Tex into a navigable, searchable structure.
@@ -18,7 +19,7 @@ def TexSoup(tex):
     1. Tex is parsed, cleaned, and packaged.
     2. Structure fed to TexNodes for a searchable, coder-friendly interface.
 
-    :param (iterable, string) tex: the Tex source
+    :param Union[string, iterable] tex: the Tex source
     :return TexNode: object representing tex document
 
     >>> from TexSoup import TexSoup
@@ -39,7 +40,7 @@ def TexSoup(tex):
     ... Here is the prevalence of each synonym.
     ...
     ... \begin{tabular}{c c}
-    ... red lemon & uncommon \\
+    ... red lemon & uncommon \\ \n
     ... life & common
     ... \end{tabular}
     ...
@@ -55,7 +56,7 @@ def TexSoup(tex):
     'document'
     >>> soup.tabular
     \begin{tabular}{c c}
-    red lemon & uncommon \\
+    red lemon & uncommon \\ \n
     life & common
     \end{tabular}
     >>> soup.tabular.args[0]

--- a/TexSoup/tex.py
+++ b/TexSoup/tex.py
@@ -7,7 +7,7 @@ import itertools
 def read(tex):
     """Read and parse all LaTeX source
 
-    :param str tex: LaTeX source
+    :param Union[string, iterable] tex: LaTeX source
     :return TexEnv: the global environment
     """
     if isinstance(tex, str):

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -9,7 +9,9 @@ function:
 2. Generalized utilities
 """
 
-import functools, bisect
+import bisect
+import functools
+
 
 ##############
 # Decorators #
@@ -46,6 +48,7 @@ def to_buffer(f):
 class TokenWithPosition(str):
     """Enhanced string object with knowledge of global position."""
 
+    # noinspection PyArgumentList
     def __new__(cls, text, position):
         """Initializer for pseudo-string object.
 
@@ -214,6 +217,7 @@ class TokenWithPosition(str):
         return TokenWithPosition(stripped, self.position + offset)
 
 
+# noinspection PyTypeChecker
 class Buffer:
     """Converts string or iterable into a navigable iterator of strings
 
@@ -256,6 +260,7 @@ class Buffer:
         self.__i = 0
         self.__join = join
 
+    # noinspection PyPep8Naming
     def hasNext(self):
         """Returns whether or not there is another element."""
         return bool(self.peek())
@@ -289,7 +294,7 @@ class Buffer:
     def num_forward_until(self, condition):
         """Forward until one of the provided matches is found.
 
-        :param matches: set of valid strings
+        :param condition: set of valid strings
 
         >>> b = Buffer('abcdef')
         >>> b.num_forward_until(lambda s: s in 'def')
@@ -321,7 +326,7 @@ class Buffer:
         was met. In other words, the condition will be true for the remainder
         of the buffer.
 
-        :param matches: set of valid strings
+        :param condition: set of valid strings
 
         >>> b = Buffer('abcdef')
         >>> b.forward_until(lambda s: s in 'def')

--- a/examples/solution_length.py
+++ b/examples/solution_length.py
@@ -19,12 +19,13 @@ from TexSoup import TexSoup
 def sollen(tex, command):
     r"""Measure solution length
 
-    :param (str, buffer) tex: the LaTeX source as a string or file buffer
+    :param Union[str, buffer] tex: the LaTeX source as a string or file buffer
     :param str command: the command denoting a solution i.e., if the tex file
         uses '\answer{<answer here>}', then the command is 'answer'.
     :return int: the solution length
     """
     return sum(len(a.string) for a in TexSoup(tex).find_all(command))
+
 
 if __name__ == '__main__':
     print(

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,30 @@
 import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
+from setuptools.command.test import test as test_command
 
 tests_require = ['pytest', 'pytest-cov==2.5.1', 'coverage == 3.7.1', 'coveralls == 1.1']
 install_requires = []
 
-class PyTest(TestCommand):
 
+class PyTest(test_command):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
+    def __init__(self, dist, **kw):
+        super().__init__(dist, **kw)
         self.pytest_args = []
 
+    def initialize_options(self):
+        test_command.initialize_options(self)
+
     def finalize_options(self):
-        TestCommand.finalize_options(self)
+        test_command.finalize_options(self)
 
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
+
 
 VERSION = '0.1.3'
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -137,21 +137,21 @@ def test_ignore_environment():
     \min_x \|Ax - b\|_2^2 + \lambda \|x\|_2^2
     \end{verbatim}
     $$\min_x \|Ax - b\|_2^2 + \lambda \|x\|_1^2$$
-    $$[0,1)$$
+    \[[0,1)\]
     \begin{flalign} will break if TexSoup starts parsing math[ \end{flalign}
     \begin{align*} hah [ \end{align*}
     """)
     verbatim = list(list(soup.children)[1].contents)[0]
     assert len(list(soup.contents)) == 6, 'Special environments not recognized.'
     assert str(list(soup.children)[0]) == \
-           '\\begin{equation}\min_x \|Ax - b\|_2^2\\end{equation}'
+        '\\begin{equation}\min_x \|Ax - b\|_2^2\\end{equation}'
 
     # hacky workaround for odd string types
     assert verbatim[0] == '\n' and verbatim[1:].startswith('   '), \
         'Whitespace not preserved: {}'.format(verbatim)
     assert str(list(soup.children)[2]) == \
         '$$\min_x \|Ax - b\|_2^2 + \lambda \|x\|_1^2$$'
-    assert str(list(soup.children)[3]) == '$$[0,1)$$'
+    assert str(list(soup.children)[3]) == '\[[0,1)\]'
 
 
 def test_inline_math():
@@ -159,9 +159,14 @@ def test_inline_math():
     soup = TexSoup("""
     \begin{itemize}
     \item This $e^{i\pi} = -1$
+    \item How \(e^{i\pi} + 1 = 0\)
+    \item Therefore!
     \end{itemize}""")
     assert '$e^{i\pi} = -1$' in str(soup), 'Math environment not intact.'
-    assert '$e^{i\pi} = -1$' in str(soup.item), \
+    assert '$e^{i\pi} = -1$' in str(list(soup.children)[0]), \
+        'Inline environment not associated with correct expression.'
+    assert '\(e^{i\pi} + 1 = 0\)' in str(soup), 'Math environment not intact.'
+    assert '\(e^{i\pi} + 1 = 0\)' in str(list(soup.children)[1]), \
         'Inline environment not associated with correct expression.'
 
 
@@ -172,10 +177,10 @@ def test_escaped_characters():
     """
     soup = TexSoup("""
     \begin{itemize}
-    \item Ice cream costs \$4-\$5 around here. \}\]\{\[
+    \item Ice cream costs \$4-\$5 around here. \}[\{]
     \end{itemize}""")
     assert str(soup.item).strip() == r'\item Ice cream costs \$4-\$5 around ' \
-                                     r'here. \}\]\{\['
+                                     r'here. \}[\{]'
     assert '\\$4-\\$5' in str(soup), 'Escaped characters not properly rendered.'
 
 
@@ -203,8 +208,8 @@ def test_item_parsing():
 \end{itemize}""")
     zeroitem = soup.item.extra[0].strip()
     assert not zeroitem, \
-        'Zeroth item should not include content, but contains: {}'\
-            .format(zeroitem)
+        'Zeroth item should not include content, but contains: {}' \
+        .format(zeroitem)
     soup = TexSoup(r"""\begin{itemize}
 \item second item
 \item
@@ -312,10 +317,10 @@ def test_math_environment_whitespace():
     soup2 = TexSoup(r"""\gamma = \beta\begin{notescaped}\gamma = \beta\end{notescaped}
 \begin{equation*}\beta = \gamma\end{equation*}""")
     assert str(soup2.find('equation*')) == \
-           r'\begin{equation*}\beta = \gamma\end{equation*}'
+        r'\begin{equation*}\beta = \gamma\end{equation*}'
     assert str(soup2).startswith(r'\gamma = \beta')
     assert str(soup2.notescaped) == \
-           r'\begin{notescaped}\gamma = \beta\end{notescaped}'
+        r'\begin{notescaped}\gamma = \beta\end{notescaped}'
 
 
 def test_math_environment_escape():


### PR DESCRIPTION
Adds support for the `\\( ... \\)` and `\\[ ... \\]` shorthand notation for the math and display math environments in LaTeX. Explained in [LaTeX An unofficial reference manual](http://texdoc.net/texmf-dist/doc/latex/latex2e-help-texinfo/latex2e.pdf) at section 16 of the manual. The documentation and tests have been adapted for the changes and other modifications.