### PR TITLE
Fixes and Features: arguments and everything

### DIFF
--- a/TexSoup/__init__.py
+++ b/TexSoup/__init__.py
@@ -12,14 +12,14 @@ from TexSoup.tex import *
 
 
 # noinspection PyPep8Naming
-def TexSoup(tex):
+def TexSoup(tex_code):
     r"""
     At a high-level, parses provided Tex into a navigable, searchable structure.
     This is accomplished in two steps:
     1. Tex is parsed, cleaned, and packaged.
     2. Structure fed to TexNodes for a searchable, coder-friendly interface.
 
-    :param Union[string, iterable] tex: the Tex source
+    :param Union[string, iterable] tex_code: the Tex source
     :return TexNode: object representing tex document
 
     >>> from TexSoup import TexSoup
@@ -82,5 +82,5 @@ def TexSoup(tex):
     >>> soup
     SOUP
     """
-    parsed, src = read(tex)
+    parsed, src = read(tex_code)
     return TexNode(parsed, src=src)

--- a/examples/count_references.py
+++ b/examples/count_references.py
@@ -30,8 +30,10 @@ def count(tex):
     # create dictionary mapping label to number of references
     return dict((label, soup.find_all('\ref{%s}' % label)) for label in labels)
 
+
 if __name__ == '__main__':
     counts = count(open(input('Tex file:').strip()))
+
     if not counts:
         print('No labels found.')
     else:

--- a/examples/list_everything.py
+++ b/examples/list_everything.py
@@ -1,0 +1,42 @@
+"""
+List Everything
+---
+This script creates a tree of lists from a given LaTeX document.
+To use it, run
+
+    python list_everything.py
+
+after installing TexSoup.
+
+@author: Simon Maenaut
+@e-mail: simon@ulyssis.org
+"""
+import TexSoup
+import pprint
+
+
+def everything(tex_tree):
+    result = []
+    for tex_code in tex_tree:
+        if isinstance(tex_code, TexSoup.TexEnv):
+            result.append([tex_code.begin + str(tex_code.arguments), everything(tex_code.everything), tex_code.end])
+        elif isinstance(tex_code, TexSoup.TexCmd):
+            result.append(["\\" + tex_code.name + str(tex_code.arguments)])
+        elif isinstance(tex_code, TexSoup.TokenWithPosition):
+            result.append(tex_code.text)
+        elif isinstance(tex_code, TexSoup.Arg):
+            result.append(["{", everything(TexSoup.TexSoup(tex_code.value).expr.everything), "}"])
+        else:
+            result.append([str(tex_code)])
+
+    return result
+
+
+# Run programme as main file
+if __name__ == '__main__':
+
+    tex_file = open(input('LaTex file:').strip())
+    tex_soup = TexSoup.TexSoup(tex_file)
+    tex_text = everything(tex_soup.expr.everything)
+    print("LaTeX Contents:\n== == ==\n\n")
+    pprint.pprint(tex_text)

--- a/examples/resolve_imports.py
+++ b/examples/resolve_imports.py
@@ -40,7 +40,9 @@ def resolve(tex):
 
     return soup
 
+
 if __name__ == '__main__':
     new_soup = resolve(open(input('Source Tex file:').strip()))
+
     with open(input('Destination Tex file:').strip()) as f:
         f.write(repr(new_soup))

--- a/examples/simple_conversion.py
+++ b/examples/simple_conversion.py
@@ -1,0 +1,72 @@
+"""
+Simple Conversion
+---
+This script converts a given LaTeX document to a json file and checks the conversion.
+To use it, run
+
+    python simple_conversion.py
+
+after installing TexSoup.
+
+@author: Simon Maenaut
+@e-mail: simon@ulyssis.org
+"""
+import TexSoup
+import json
+
+
+def to_dictionary(tex_tree):
+    str_tree = []
+    for i in tex_tree:
+        if isinstance(i, list):
+            str_tree.append(i)
+        elif isinstance(i, TexSoup.TexEnv):
+            str_tree.append(
+                {
+                    i.name: [
+                        {"begin": i.begin + str(i.arguments)},
+                        to_dictionary(i.everything),
+                        {"end": i.end},
+                    ]
+                }
+            )
+        elif isinstance(i, TexSoup.TexCmd):
+            str_tree.append({i.name: "\\" + i.name + str(i.arguments)})
+        elif isinstance(i, TexSoup.TokenWithPosition):
+            str_tree.append(str(i.text))
+        elif isinstance(i, TexSoup.Arg):
+            str_tree.append(["{", to_dictionary(TexSoup.TexSoup(i.value).expr.everything), "}"])
+        else:
+            str_tree.append(str(i))
+
+    return str_tree
+
+
+def to_latex(tex_json):
+    if isinstance(tex_json, dict):
+        tex_code = "".join([to_latex(val) for val in tex_json.values()])
+    elif isinstance(tex_json, list):
+        tex_code = "".join([to_latex(val) for val in tex_json])
+    else:
+        tex_code = tex_json
+
+    return tex_code
+
+
+# Run programme as main file.
+# This should always print True as output.
+if __name__ == '__main__':
+
+    import os
+
+    tex_path = input('LaTex file:').strip()
+    tex_text = open(tex_path).read()
+    tex_dict = {"latex": {"contents": to_dictionary(TexSoup.TexSoup(tex_text).expr.everything)}}
+
+    new_path = ".".join(tex_path.split(".")[:-1]) + "__tmp.json"
+    json.dump(tex_dict, open(new_path, "x"), indent="  ")
+    new_json = json.load(open(new_path))
+    os.remove(new_path)
+    new_text = to_latex(new_json)
+
+    print(tex_text == new_text, "\n\n\n", json.dumps(new_json, indent="  "))

--- a/examples/structure_diagram.py
+++ b/examples/structure_diagram.py
@@ -1,0 +1,48 @@
+"""
+Structure Diagram
+---
+This script creates a structure diagram from a given LaTeX document.
+To use it, run
+
+    python structure_diagram.py
+
+after installing TexSoup.
+
+@author: Simon Maenaut
+@e-mail: simon@ulyssis.org
+"""
+import TexSoup
+import textwrap
+
+
+def tex_read(tex_soup, prefix=" |- "):
+    result = ""
+    for tex_code in tex_soup:
+        if isinstance(tex_code, TexSoup.TexEnv):
+            result += tex_read((prefix + tex_code.begin + str(tex_code.arguments)
+                                + "\n" + textwrap.indent(tex_read(tex_code.everything), "\t")
+                                + "\n" + prefix + tex_code.end).splitlines(), prefix="")
+        elif isinstance(tex_code, TexSoup.TexCmd):
+            result += textwrap.indent("\\" + tex_code.name + str(tex_code.arguments), prefix, lambda line: True)
+        elif isinstance(tex_code, TexSoup.TokenWithPosition):
+            result += textwrap.indent(tex_code.text.strip(), prefix, lambda line: True)
+        elif isinstance(tex_code, TexSoup.Arg):
+            result += tex_read((prefix + "{" + "\n"
+                                + textwrap.indent(tex_read(TexSoup.TexSoup(tex_code.value).expr.everything), "\t")
+                                + "\n" + prefix + "}").splitlines(), prefix="")
+        else:
+            result += textwrap.indent(str(tex_code), prefix)
+        if not result.endswith("\n"):
+            result += "\n"
+
+    return result
+
+
+# Run programme as main file
+if __name__ == '__main__':
+
+    tex_path = input('LaTex file:').strip()
+    tex_text = open(tex_path).read()
+    tex_tree = tex_read(TexSoup.TexSoup(tex_text).expr.everything)
+    print("LaTeX Contents:\n== == ==\n\n")
+    print(tex_tree)

--- a/tests/config.py
+++ b/tests/config.py
@@ -2,9 +2,11 @@ from TexSoup import TexSoup
 import os
 import pytest
 
+
 def seed(path):
     """Filepath relative to test directory"""
     return os.path.join(os.path.split(os.path.realpath(__file__))[0], path)
+
 
 ############
 # FIXTURES #

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,14 @@
-from .config import *
 from TexSoup.utils import TokenWithPosition
+from tests.config import chikin
 import re
 
 ##############
 # NAVIGATION #
 ##############
+
+
+if chikin:
+    pass
 
 
 def test_navigation_attributes(chikin):
@@ -52,6 +56,7 @@ def test_navigation_positions(chikin):
     # get position of section
     section_pos = list(chikin.find_all('section'))[1].name.position
     assert chikin.char_pos_to_line(section_pos) == (15, 1)
+
 
 ##########
 # SEARCH #
@@ -108,6 +113,7 @@ def test_add_children_at(chikin):
     assert 'asdfghjkl' in str(chikin)
     assert str(chikin[0]) == 'asdfghjkl'
 
+
 #########
 # TEXT #
 ########
@@ -118,12 +124,14 @@ def test_text(chikin):
     assert 'Chikin Fly' in text
     assert 'waddle\n' in text
 
+
 def test_search_regex(chikin):
     """Find all occurenses of a regex in the document text"""
     matches = list(chikin.search_regex(r"unless[a-z ]*"))
     assert len(matches) == 1
     assert matches[0] == "unless ordered to squat"
     assert matches[0].position == 341
+
 
 def test_search_regex_precompiled_pattern(chikin):
     """Find all occurenses of a regex in the document text"""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -97,7 +97,7 @@ def test_command_name_parse():
     assert with_space_with_arg.section.string == 'hula'
 
     with_linebreak_with_arg = TexSoup(r"""\section
-{hula}""")
+    {hula}""")
     assert with_linebreak_with_arg.section.string == 'hula'
 
 
@@ -143,14 +143,10 @@ def test_ignore_environment():
     """)
     verbatim = list(list(soup.children)[1].contents)[0]
     assert len(list(soup.contents)) == 6, 'Special environments not recognized.'
-    assert str(list(soup.children)[0]) == \
-        '\\begin{equation}\min_x \|Ax - b\|_2^2\\end{equation}'
-
+    assert str(list(soup.children)[0]) == '\\begin{equation}\min_x \|Ax - b\|_2^2\\end{equation}'
     # hacky workaround for odd string types
-    assert verbatim[0] == '\n' and verbatim[1:].startswith('   '), \
-        'Whitespace not preserved: {}'.format(verbatim)
-    assert str(list(soup.children)[2]) == \
-        '$$\min_x \|Ax - b\|_2^2 + \lambda \|x\|_1^2$$'
+    assert verbatim[0] == '\n' and verbatim[1:].startswith('   '), 'Whitespace not preserved: {}'.format(verbatim)
+    assert str(list(soup.children)[2]) == '$$\min_x \|Ax - b\|_2^2 + \lambda \|x\|_1^2$$'
     assert str(list(soup.children)[3]) == '\[[0,1)\]'
 
 
@@ -162,25 +158,21 @@ def test_inline_math():
     \item How \(e^{i\pi} + 1 = 0\)
     \item Therefore!
     \end{itemize}""")
-    assert '$e^{i\pi} = -1$' in str(soup), 'Math environment not intact.'
-    assert '$e^{i\pi} = -1$' in str(list(soup.children)[0]), \
-        'Inline environment not associated with correct expression.'
-    assert '\(e^{i\pi} + 1 = 0\)' in str(soup), 'Math environment not intact.'
-    assert '\(e^{i\pi} + 1 = 0\)' in str(list(soup.children)[1]), \
-        'Inline environment not associated with correct expression.'
+    assert '$e^{i\pi} = -1$' in str(soup), 'Math environment not kept intact.'
+    assert '$e^{i\pi} = -1$' in str(list(soup.children)[0]), 'Environment incorrectly associated.'
+    assert '\(e^{i\pi} + 1 = 0\)' in str(soup), 'Math environment not kept intact.'
+    assert '\(e^{i\pi} + 1 = 0\)' in str(list(soup.children)[1]), 'Environment incorrectly associated.'
 
 
 def test_escaped_characters():
     """Tests that special characters are escaped properly.
-
     Formerly, escaped characters would be rendered as latex commands.
     """
     soup = TexSoup("""
     \begin{itemize}
     \item Ice cream costs \$4-\$5 around here. \}[\{]
     \end{itemize}""")
-    assert str(soup.item).strip() == r'\item Ice cream costs \$4-\$5 around ' \
-                                     r'here. \}[\{]'
+    assert str(soup.item).strip() == r'\item Ice cream costs \$4-\$5 around here. \}[\{]'
     assert '\\$4-\\$5' in str(soup), 'Escaped characters not properly rendered.'
 
 
@@ -188,58 +180,56 @@ def test_math_environment_weirdness():
     """Tests that math environment interacts correctly with other envs."""
     soup = TexSoup(r"""\begin{a} \end{a}$ b$""")
     assert '$' not in str(soup.a), 'Math env snuck into begin env.'
-    soup2 = TexSoup(r"""\begin{a} $ b$ \end{a}""")
-    assert '$' in str(next(soup2.a.contents)), 'Math env not found in begin env'
-    soup3 = TexSoup(r"""\begin{verbatim} $ \end{verbatim}""")
-    assert soup3.verbatim is not None
+    soup = TexSoup(r"""\begin{a} $ b$ \end{a}""")
+    assert '$' in str(next(soup.a.contents)), 'Math env not found in begin env'
+    soup = TexSoup(r"""\begin{verbatim} $ \end{verbatim}""")
+    assert soup.verbatim is not None
 
 
 def test_item_parsing():
     """Tests that item parsing is valid."""
     soup = TexSoup(r"""\item aaa {\bbb} ccc""")
     assert str(soup.item) == r'\item aaa {\bbb} ccc'
-    soup2 = TexSoup(r"""\begin{itemize}
-\item hello $\alpha$
-\end{itemize}""")
-    assert str(soup2.item).strip() == r'\item hello $\alpha$'
     soup = TexSoup(r"""\begin{itemize}
-\item
-\item first item
-\end{itemize}""")
+    \item hello $\alpha$
+    \end{itemize}""")
+    assert str(soup.item).strip() == r'\item hello $\alpha$'
+    soup = TexSoup(r"""\begin{itemize}
+    \item
+    \item first item
+    \end{itemize}""")
     zeroitem = soup.item.extra[0].strip()
-    assert not zeroitem, \
-        'Zeroth item should not include content, but contains: {}' \
-        .format(zeroitem)
+    assert not zeroitem, 'Zeroth item should not include content, but contains: {}'.format(zeroitem)
     soup = TexSoup(r"""\begin{itemize}
-\item second item
-\item
+    \item second item
+    \item
 
 
-third item
-with third item
+    third item
+    with third item
 
-floating text
-\end{itemize}""")
-    thirditem = str(list(soup.find_all('item'))[1])
-    assert 'third item' in thirditem, \
-        'Item does not tolerate starting line breaks (as it should)'
-    assert 'with' in thirditem, \
-        'Item does not tolerate line break in middle (as it should)'
-    assert 'floating' not in thirditem, \
-        'Item should not tolerate multiple line breaks in middle'
+    floating text
+    \end{itemize}""")
+    all_extra = list(soup.find_all('item'))[1].extra
+    thirditem = all_extra[0] + all_extra[1]
+    assert 'third item' in thirditem, 'Item does not tolerate starting line breaks (as it should)'
+    assert 'with' in thirditem, 'Item does not tolerate line break in middle (as it should)'
+    assert 'floating' not in thirditem, 'Item should not tolerate multiple line breaks in middle'
+    assert thirditem.lstrip() == "third item\n    with third item\n\n"
+    assert thirditem.rstrip() == "\n\n\n    third item\n    with third item"
     soup = TexSoup(r"""\begin{itemize}
-\item This item contains code!
-\begin{lstlisting}
-Code code code
-\end{lstlisting}
-\item hello
-\end{itemize}""")
+    \item This item contains code!
+    \begin{lstlisting}
+    Code code code
+    \end{lstlisting}
+    \item hello
+    \end{itemize}""")
     assert 'Code code code' in str(soup.item.lstlisting), \
         'Item does not correctly parse contained environments.'
     soup = TexSoup(r"""\begin{itemize}
-\item\label{some-label} waddle
-\item plop
-\end{itemize}""")
+    \item\label{some-label} waddle
+    \item plop
+    \end{itemize}""")
     assert str(soup.item.label) == '\label{some-label}'
 
 
@@ -259,8 +249,8 @@ def test_items_with_labels():
     """Items can have labels with square brackets such as in the description
     environment. See Issue #32."""
     soup = TexSoup(r"""\begin{description}
-\item[Python] a high-level general-purpose interpreted programming language.
- \end{description}""")
+    \item[Python] a high-level general-purpose interpreted programming language.
+    \end{description}""")
     assert "Python" in soup.description.item.args
 
 
@@ -268,14 +258,26 @@ def test_multiline_args():
     """Tests that macros with arguments are different lines are parsed
     properly. See Issue #31."""
     soup = TexSoup(r"""\mytitle{Essay title}
-{Essay subheading.}""")
+    {Essay subheading.}""")
     assert "Essay subheading." in soup.mytitle.args
     # Only one newline allowed
     soup = TexSoup(r"""\mytitle{Essay title}
 
-{Essay subheading.}""")
+    {Essay subheading.}""")
     assert "Essay subheading." not in soup.mytitle.args
     assert "Essay title" in soup.mytitle.args
+    soup = TexSoup(r"""\title{Arguments}
+    {appear}
+    \subtitle{everywhere}
+    in \LaTeX.
+
+    \date{\today}
+    """)
+    assert "Arguments" in soup.title.args
+    assert "appear" in soup.title.args
+    assert "everywhere" in soup.subtitle.args
+    assert "\n    in " in list(soup.contents)
+    assert len(list(soup.contents)) == 6
 
 
 ##############
@@ -314,13 +316,11 @@ def test_math_environment_whitespace():
     assert '\n' in str(children[0]), 'Whitesapce not preserved in math env.'
     assert len(children) == 1 and children[0].name == '$$', 'Math env wrong'
     assert '\$' in contents[1], 'Dollar sign not escaped!'
-    soup2 = TexSoup(r"""\gamma = \beta\begin{notescaped}\gamma = \beta\end{notescaped}
-\begin{equation*}\beta = \gamma\end{equation*}""")
-    assert str(soup2.find('equation*')) == \
-        r'\begin{equation*}\beta = \gamma\end{equation*}'
-    assert str(soup2).startswith(r'\gamma = \beta')
-    assert str(soup2.notescaped) == \
-        r'\begin{notescaped}\gamma = \beta\end{notescaped}'
+    soup = TexSoup(r"""\gamma = \beta\begin{notescaped}\gamma = \beta\end{notescaped}
+    \begin{equation*}\beta = \gamma\end{equation*}""")
+    assert str(soup.find('equation*')) == r'\begin{equation*}\beta = \gamma\end{equation*}'
+    assert str(soup).startswith(r'\gamma = \beta')
+    assert str(soup.notescaped) == r'\begin{notescaped}\gamma = \beta\end{notescaped}'
 
 
 def test_math_environment_escape():
@@ -346,10 +346,42 @@ def test_non_punctuation_command_structure():
     """
     soup = TexSoup(r"""\mycommand, hello""")
     contents = list(soup.contents)
-    assert '\mycommand' == str(contents[0]), \
-        'Comma considered part of the command.'
-    soup2 = TexSoup(r"""\hspace*{0.2in} hello \hspace*{2in} world""")
-    assert len(list(soup2.contents)) == 4, '* not recognized as part of command.'
+    assert '\mycommand' == str(contents[0]), 'Comma considered part of the command.'
+
+    soup = TexSoup(r"""\hspace*{0.2in} hello \hspace*{2in} world""")
+    assert len(list(soup.contents)) == 4, '* not recognized as part of command.'
+
+
+##########
+# BUFFER #
+##########
+
+
+def test_buffer():
+    from TexSoup.utils import Buffer
+    b = Buffer('abcdef')
+    assert b.forward_until(lambda s: s in 'def') == 'abc'
+    assert b.forward_until(lambda s: s in 'f') == 'de'
+    assert b.backward(5) == 'abcde'
+    assert b.forward_until(lambda s: s not in 'abc') == 'abc'
+    assert b.forward_until(lambda s: s in 'def') == ''
+    assert b.backward(3) == 'abc'
+    assert b.num_forward_until(lambda s: s in 'def') == 3
+    assert b.forward(3) == 'abc'
+    assert b.num_forward_until(lambda s: s in 'g') == 3
+    assert b.forward(3) == 'def'
+    assert b.num_forward_until(lambda s: s in 'z') == 0
+    assert b.backward(6) == 'abcdef'
+    assert b.num_forward_until(lambda s: s not in 'abc') == 3
+
+
+def test_to_buffer():
+    from TexSoup.utils import to_buffer
+    f = to_buffer(lambda x: x[:])
+    assert f('asdf') == 'asdf'
+    g = to_buffer(lambda x: x)
+    assert not g('').hasNext()
+    assert next(g('asdf')) == 'a'
 
 
 ##########

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -44,8 +44,12 @@ def test_commands_envs_text():
     """Tests that parser for commands, environments, and strings work."""
     soup = TexSoup(r"""
     \begin{document}
-    \section{Chikin Tales}
-    \subsection{Chikin Fly}
+    \title{Chikin}
+    \date{\today}
+    \section
+    [Tales]{Chikin Tales}
+    \subsection
+    {Chikin Fly}
 
     Here is what chickens do:
 
@@ -59,10 +63,18 @@ def test_commands_envs_text():
     doc = next(soup.children)
     assert doc.name == 'document'
     contents, children = list(doc.contents), list(doc.children)
-    assert str(children[0]) == '\section{Chikin Tales}'
-    assert str(children[1]) == '\subsection{Chikin Fly}'
-    assert len(children) == 3
-    assert len(contents) == 4
+    assert str(children[0]) == r'\title{Chikin}'
+    assert str(children[1]) == r'\date{\today}'
+    assert str(children[2]) == r'\section[Tales]{Chikin Tales}'
+    assert str(children[3]) == r'\subsection{Chikin Fly}'
+    assert len(children) == 5
+    assert len(contents) == 6
+    everything = list(doc.expr.everything)
+    assert len(everything) == 12
+    arguments = str(doc.section.expr.arguments)
+    assert arguments == "\n    [Tales]{Chikin Tales}"
+    arguments_list = [str(arg) for arg in doc.section.expr.arguments]
+    assert arguments_list == ['\n    ', '[Tales]', '{Chikin Tales}']
 
 
 #########
@@ -224,8 +236,8 @@ def test_item_parsing():
     \end{lstlisting}
     \item hello
     \end{itemize}""")
-    assert 'Code code code' in str(soup.item.lstlisting), \
-        'Item does not correctly parse contained environments.'
+    assert ' Code code code' in str(soup.item.lstlisting), 'Item does not correctly parse contained environments.'
+    assert '\n    Code code code\n    ' in soup.item.lstlisting.expr.everything
     soup = TexSoup(r"""\begin{itemize}
     \item\label{some-label} waddle
     \item plop

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -11,8 +11,8 @@ from TexSoup import TexSoup
 #########
 
 
-def test_commands_without_arguments():
-    """Tests that commands without arguments can still be searched."""
+def test_commands_without_any_sort_arguments():
+    """Tests that commands without any sort argument can still be searched."""
     soup = TexSoup(r"""
     \Question \textbf{Question Title}
 
@@ -27,10 +27,12 @@ def test_commands_without_arguments():
     assert soup.find('section') is None
 
 
-def test_commands_without_arguments_searchable():
-    """Tests that command without arguments can still be found."""
-    soup = TexSoup(r"""\Question (10 points)
-This is the question here.
-
-\Question (6 points)""")
-    assert len(list(soup.find_all('Question'))) == 2
+def test_commands_with_one_or_more_arguments():
+    """Tests that commands with one or more argument can still be searched."""
+    soup = TexSoup(r"""
+    \section{Chikin Tales}
+    \subsection{Chikin Fly}
+    \section{Chikin Sequel}
+    """)
+    assert len(list(soup.find_all('section'))) == 2
+    assert soup.find('title') is None


### PR DESCRIPTION
Fixes some minor issues with `TokenWithPosition` (adding and stripping) and adds two new expression properties: `arguments` and `everything`. The `arguments` property of a `TexExpr` instance returns all the arguments of the command similar to the `args` property, however it also includes all the whitespace between the arguments. The `everything` property of a `TexEnv` instance returns the entire contents of the environment similar to the `contents` property, however it also includes all the whitespace between the parts. There are also some other minor fixes and changes, such as in the item parsing function. Finally, there are new tests included for these features as well as some examples to showcase some possible uses of these new features.