### PR TITLE
BUG: Fix #48 and #55 by checking math environment not preceeded by "\\"

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -174,7 +174,8 @@ def tokenize_math(text):
     >>> tokenize_math(b)
     '$$'
     """
-    if text.startswith('$') and (text.position == 0 or text.peek(-1) != '\\'):
+    if text.startswith('$') and (
+       text.position == 0 or text.peek(-1) != '\\' or text.endswith(r'\\')):
         starter = '$$' if text.startswith('$$') else '$'
         return TokenWithPosition(text.forward(len(starter)), text.position)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -196,6 +196,12 @@ def test_math_environment_weirdness():
     assert '$' in str(next(soup.a.contents)), 'Math env not found in begin env'
     soup = TexSoup(r"""\begin{verbatim} $ \end{verbatim}""")
     assert soup.verbatim is not None
+    # GH48
+    soup = TexSoup(r"""a\\$a$""")
+    assert '$' in str(soup), 'Math env not correctly parsed after \\\\'
+    # GH55
+    soup = TexSoup(r"""\begin{env} text\\$formula$ \end{env}""")
+    assert '$' in str(soup.env), 'Math env not correctly parsed after \\\\'
 
 
 def test_item_parsing():


### PR DESCRIPTION
Hi, 

As the title says I think this fixes #48 and #55 (which are two versions of the same thing). 
Math environments weren't correctly picked up if preceeded by backslash even though after a double backslash they probably should.
I've added a couple of tests to cover each issue. All tests pass.
