### PR TITLE
parse '\ ' as a command (and escape other characters)

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -562,7 +562,8 @@ class TexExpr(object):
     """
 
     def __init__(self, name, contents=(), args=(), preserve_whitespace=False):
-        self.name = name.strip()
+        # self.name = name.strip()
+        self.name = name
         self.args = TexArgs(args)
         self.parent = None
         self._contents = list(contents) or []
@@ -877,7 +878,8 @@ class Arg(object):
                             ' mistyped closing punctuation, misalignment.' % (str(s)))
         for arg in arg_type:
             if arg.__is__(s):
-                return arg(arg.__strip__(s))
+                return arg(s)
+                # return arg(arg.__strip__(s))
         raise TypeError('Malformed argument. Must be an Arg or a string in '
                         'either brackets or curly braces.')
 

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -120,6 +120,16 @@ def tokenize_punctuation_command(text):
                 return text.forward(len(point) + 1)
 
 
+ESCAPED_CHARACTERS = {" "}
+
+@token('escaped_character')
+def tokenize_escaped_character(text):
+    if text.peek() == "\\":
+        for char in ESCAPED_CHARACTERS:
+            if text.peek((1, len(char) + 1)) == char:
+                return text.forward(len(char) + 1)
+
+
 @token('command')
 def tokenize_command(text):
     """Process command, but ignore line breaks. (double backslash)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,4 @@
-from TexSoup import TexSoup
 import pytest
-
 
 ###############
 # BASIC TESTS #
@@ -357,6 +355,15 @@ def test_math_environment_escape():
     soup = TexSoup(r"$ \$ $")
     contents = list(soup.contents)
     assert r'\$' in contents[0][0], 'Dollar sign not escaped!'
+
+
+def test_parse_space_command():
+    """Tests that "\ <word>" is parsed as a command followed by a word."""
+    soup = TexSoup(r"\ word")
+    contents = list(soup.contents)
+    assert len(contents) == 2
+    assert str(contents[0]) == r'\ '
+    assert str(contents[1]) == r'word'
 
 
 def test_punctuation_command_structure():


### PR DESCRIPTION
Hi @alvinwan! Thank you for creating and maintaining this useful tool :-D

When I wanted to print out the contents of the soup, I found that sometimes the TeX was getting rewritten in a way that wasn't quite semantically equivalent. I learned that a string like `\ word` (space, followed by "word") was parsed as the command `\word'.

```python
>>> from TexSoup import TexSoup
>>> soup = TexSoup("\\ word") # <-- right after the "\\" is a space
>>> print(soup)
\word  # <-- the space has been stripped
```

This means that when the TeX is printed back out, a space has been removed and a TeX processing engine will look for a probably nonexistent command `\word`.

In this pull request, I took a stab at processing a `\ ` as an escaped character. I imagine maybe this could be extended to process other escaped characters into commands (e.g., `\#`, `\$`, etc.) as well. Could you take a look and see if this is something you'd want in master?

To get spaces to print out correctly, I needed to [disable the stripping of space](https://github.com/alvinwan/TexSoup/compare/master...andrewhead:master#diff-cb29fa6567ea01b2984213eeb001bda8R565-R566) in command names, and also disabled stripping in arguments just in case. Maybe this is a no-no, in which case is there another way to preserve to avoid stripping spaces when I want to print out the soup as a tex file?