### PR TITLE
Remove test dependencies from install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 install:
   - python setup.py install
+  - python setup.py easy_install $(python3 -c 'import distutils.core; print(" ".join(distutils.core.run_setup("setup.py").tests_require))')
 
 script:
   - py.test --cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 sudo: false
 
 python:
-  - "3.4.2"
+  - "3.4.5"
 
 install:
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as test_command
 
-tests_require = ['pytest', 'pytest-cov==2.5.1', 'coverage == 3.7.1', 'coveralls == 1.1']
+tests_require = ['pytest', 'pytest-cov==2.5.1', 'coverage==3.7.1', 'coveralls==1.1']
 install_requires = []
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=['TexSoup'],
     cmdclass={'test': PyTest},
     tests_require=tests_require,
-    install_requires=install_requires + tests_require,
+    install_requires=install_requires,
     download_url='https://github.com/alvinwan/TexSoup/archive/%s.zip' % VERSION,
     classifiers=[
         "Topic :: Utilities",


### PR DESCRIPTION
Hi, thank you for creating and maintaining this nice library :)

This PR mainly removes the test dependencies from the install dependencies. (I also fixed the configuration for TravisCI to keep the status green.)

**Purpose**: Since TexSoup lists `coverage==3.7.1` in its install dependencies, a library depending on TexSoup cannot use other version of `coverage`. I guess that the test dependencies are listed as install dependencies to make everything prepared by running `python setup.py install` on TravisCI. However, to avoid the above-mentioned problem, I suggest removing them from the install dependencies.

**Alternative solution**: I think it would be better to use tox for testing, but that solution requires larger changes. So I chose the hacky way (https://github.com/alvinwan/TexSoup/pull/85/commits/fea809c57c7fcf891c5dd5deb938232ea757dfeb) to solve the problem. If you prefer using tox, I will close this PR and create another using tox.

Thank you again for your work on this library. Any kinds of feedbacks are appreciated :)
