### PR TITLE
Fix examples

### DIFF
--- a/examples/count_references.py
+++ b/examples/count_references.py
@@ -28,7 +28,13 @@ def count(tex):
     labels = set(label.string for label in soup.find_all('label'))
 
     # create dictionary mapping label to number of references
-    return dict((label, soup.find_all('\ref{%s}' % label)) for label in labels)
+    label_refs = {}
+    for label in labels:
+        refs = soup.find_all('\\ref{%s}' % label)
+        pagerefs = soup.find_all('\\pageref{%s}' % label)
+        label_refs[label] = len(list(refs)) + len(list(pagerefs))
+
+    return label_refs
 
 
 if __name__ == '__main__':

--- a/examples/list_everything.py
+++ b/examples/list_everything.py
@@ -16,12 +16,16 @@ import pprint
 
 
 def everything(tex_tree):
+    """
+    Accepts a list of Union[TexNode,TokenWithPosition] and returns a nested list
+    of strings of the entire source document.
+    """
     result = []
     for tex_code in tex_tree:
         if isinstance(tex_code, TexSoup.TexEnv):
-            result.append([tex_code.begin + str(tex_code.arguments), everything(tex_code.all), tex_code.end])
+            result.append([tex_code.begin + str(tex_code.args), everything(tex_code.all), tex_code.end])
         elif isinstance(tex_code, TexSoup.TexCmd):
-            result.append(["\\" + tex_code.name + str(tex_code.arguments)])
+            result.append(["\\" + tex_code.name + str(tex_code.args)])
         elif isinstance(tex_code, TexSoup.TokenWithPosition):
             result.append(tex_code.text)
         elif isinstance(tex_code, TexSoup.Arg):

--- a/examples/resolve_imports.py
+++ b/examples/resolve_imports.py
@@ -7,7 +7,7 @@ tex document. To use it, run
 
     python resolve_imports.py
 
-after installing TexSoup.
+after installing TexSoup. The result is similar to the command `latexpand`.
 
 @author: Alvin Wan
 @site: alvinwan.com
@@ -38,11 +38,15 @@ def resolve(tex):
     for include in soup.find_all('include'):
         include.replace_with(*resolve(open(include.args[0])).contents)
 
+    # resolve inputs
+    for _input in soup.find_all('input'):
+        _input.replace_with(*resolve(open(_input.args[0])).contents)
+
     return soup
 
 
 if __name__ == '__main__':
     new_soup = resolve(open(input('Source Tex file:').strip()))
 
-    with open(input('Destination Tex file:').strip()) as f:
+    with open(input('Destination Tex file:').strip(), 'w') as f:
         f.write(repr(new_soup))

--- a/examples/simple_conversion.py
+++ b/examples/simple_conversion.py
@@ -24,14 +24,14 @@ def to_dictionary(tex_tree):
             str_tree.append(
                 {
                     i.name: [
-                        {"begin": i.begin + str(i.arguments)},
+                        {"begin": i.begin + str(i.args)},
                         to_dictionary(i.all),
                         {"end": i.end},
                     ]
                 }
             )
         elif isinstance(i, TexSoup.TexCmd):
-            str_tree.append({i.name: "\\" + i.name + str(i.arguments)})
+            str_tree.append({i.name: "\\" + i.name + str(i.args)})
         elif isinstance(i, TexSoup.TokenWithPosition):
             str_tree.append(str(i.text))
         elif isinstance(i, TexSoup.Arg):

--- a/examples/structure_diagram.py
+++ b/examples/structure_diagram.py
@@ -19,11 +19,11 @@ def tex_read(tex_soup, prefix=" |- "):
     result = ""
     for tex_code in tex_soup:
         if isinstance(tex_code, TexSoup.TexEnv):
-            result += tex_read((prefix + tex_code.begin + str(tex_code.arguments)
+            result += tex_read((prefix + tex_code.begin + str(tex_code.args)
                                 + "\n" + textwrap.indent(tex_read(tex_code.all), "\t")
                                 + "\n" + prefix + tex_code.end).splitlines(), prefix="")
         elif isinstance(tex_code, TexSoup.TexCmd):
-            result += textwrap.indent("\\" + tex_code.name + str(tex_code.arguments), prefix, lambda line: True)
+            result += textwrap.indent("\\" + tex_code.name + str(tex_code.args), prefix, lambda line: True)
         elif isinstance(tex_code, TexSoup.TokenWithPosition):
             result += textwrap.indent(tex_code.text.strip(), prefix, lambda line: True)
         elif isinstance(tex_code, TexSoup.Arg):


### PR DESCRIPTION
I tried to run the scripts in the `examples/` folder and realized they needed little touch ups here and there in order to run. Presumably in an older version `args` was called `arguments`.

Tested on a few sources and they all work now.