### PR TITLE
Test for "load/edit/save" workflow

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -819,7 +819,7 @@ class TexCmd(TexExpr):
     def __str__(self):
         if self._contents:
             return '\\%s%s %s' % (self.name, self.args, ''.join(
-                [str(e) for e in self.contents]))
+                [str(e) for e in self._contents]))
         return '\\%s%s' % (self.name, self.args)
 
     def __repr__(self):

--- a/tests/config.py
+++ b/tests/config.py
@@ -16,3 +16,11 @@ def seed(path):
 def chikin():
     """Instance of the chikin tex file"""
     return TexSoup(open(seed('samples/chikin.tex')))
+
+
+@pytest.fixture(scope='function')
+def pancake():
+    """Content of the pancake tex file"""
+    with open(seed('samples/pancake.tex')) as fp:
+        return fp.read()
+

--- a/tests/samples/pancake.tex
+++ b/tests/samples/pancake.tex
@@ -1,0 +1,36 @@
+\documentclass[a4paper]{article}
+
+\begin{document}
+
+\section{Pancake}
+
+\subsection{Ingredients}
+\label{ingredients}
+
+This is a pancake recipe that at the same time serves as \LaTeX test document. Put the following ingredients in a big bowl (make sure to add flour as last ingredient -- the order of the others is not important):
+
+\begin{description}
+\item[6 eggs] whithout shells but egg white and yolk together
+\item[1 liter milk] the fresh one if possible with normal 3.5\% fat
+\item[5~g salt] I hope you have a good scale or do such things often
+\item[2 spoons of oil] use oil that's heat resistant like sun flower oil
+\item[500~g flour] and pour it in while steering
+\end{description}
+
+
+\subsection{Baking}
+
+Prepare the dough like discribed in section \ref{ingredients}.
+Heat up a pan (use some oil if needed). Take a pan and put dough in such it covers the base. Wait approximately 1 to 2 minutes until the dough is no more fluid. Turn the pancake and bake the other side as well (approximately 1 minute). Continue until you have no more dough.
+
+
+Some suggestions:
+\begin{itemize}
+	\item Tastes wonderfully with yoghurt and sugar
+	\item Some people perfer jam
+	\item Cheese, bakon and eggs are also an option but if you are in favor of those, put them already into the pan when you bake the second side of the pancake.
+\end{itemize}
+
+\emph{Enjoy your meal!}
+
+\end{document}

--- a/tests/test_load_edit_save.py
+++ b/tests/test_load_edit_save.py
@@ -1,0 +1,24 @@
+from TexSoup import TexSoup
+from tests.config import pancake
+
+
+########################
+# LOAD EDIT SAVE TESTS #
+########################
+
+
+def test_load_save(pancake):
+    """Tests whether a LaTeX document can be loaded and saved."""
+    soup = TexSoup(pancake)
+    treated_pancake = str(soup)
+    assert treated_pancake == pancake
+
+
+def test_load_edit_save(pancake):
+    """Tests whether a LaTeX document can be loaded, modified and saved."""
+    soup = TexSoup(pancake)
+    emph = soup.find('emph')
+    emph.delete()
+    pancake_no_emph_soup = str(soup)
+    pancake_no_emph_replace = pancake.replace(r'\emph{Enjoy your meal!}', '')
+    assert pancake_no_emph_soup == pancake_no_emph_replace


### PR DESCRIPTION
I used TexSoup successfully to remove all un-referenced labels from a big LaTeX file. My workflow was:
* Load the document with TexSoup
* Modify the tree with Python
* Save it back to file.

It worked well, however, some parts of the LaTeX file were modified as well, specifically description environments.

```
\begin{description}
\item[egg] white and round
\end{description}
```
gets
```
\begin{description}
\item[egg] eggwhite and round
\end{description}
```
(the text in the square brackets is duplicated).

With this pull request I don't fix the issue but I create a test case that shows the problem (currently it fails as expected).