### PR TITLE
Refactor parsing

### DIFF
--- a/TexSoup/__init__.py
+++ b/TexSoup/__init__.py
@@ -60,7 +60,7 @@ def TexSoup(tex_code, skip_envs=()):
     red lemon & uncommon \\ \n
     life & common
     \end{tabular}
-    >>> soup.tabular.args[0].value
+    >>> soup.tabular.args[0].string
     'c c'
     >>> soup.itemize
     \begin{itemize}

--- a/TexSoup/category.py
+++ b/TexSoup/category.py
@@ -9,21 +9,21 @@ import string
 others = set(string.printable) - set(string.ascii_letters) - set('{}\\$&\n\r#^_~%\x00\x7d \t[]()')
 CATEGORY_CODES = {
     CC.Escape:     '\\',
-    CC.GroupStart:  '{',  # not used
-    CC.GroupEnd:    '}',  # not used
-    CC.MathSwitch:  '$',  # $$ checked in tokenize_math
+    CC.GroupStart:  '{',
+    CC.GroupEnd:    '}',
+    CC.MathSwitch:  '$',
     CC.Alignment:   '&',  # not used
     CC.EndOfLine:   ('\n', '\r'),
     CC.Macro:       '#',  # not used
     CC.Superscript: '^',  # not used
     CC.Subscript:   '_',  # not used
-    CC.Ignored:     chr(0),  # not used
-    CC.Spacer:      (chr(32), chr(9)),    # not used
+    CC.Ignored:     chr(0),
+    CC.Spacer:      (chr(32), chr(9)),
     CC.Letter:      tuple(string.ascii_letters),  # + lots of unicode
-    CC.Other:       tuple(others),  # not defined, just anything left
+    CC.Other:       tuple(others),
     CC.Active:      '~',  # not used
     CC.Comment:     '%',
-    CC.Invalid:      chr(127),  # not used
+    CC.Invalid:      chr(127),
 
     # custom
     CC.OpenBracket: '[',

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -836,13 +836,13 @@ class TexMathEnv(TexEnv):
 class TexDisplayMathEnv(TexMathEnv):
 
     name = 'displaymath'
-    fmt = '\[%s\]'
+    fmt = r'\[%s\]'
 
 
 class TexMathEnv(TexMathEnv):
 
     name = 'math'
-    fmt = '\(%s\)'
+    fmt = r'\(%s\)'
 
 
 class TexCmd(TexExpr):
@@ -1108,8 +1108,6 @@ class TexArgs(list):
         self.extend(args)
 
     def __coerce(self, arg):
-        if isinstance(arg, TexText):
-            arg = arg._text
         if isinstance(arg, str) and not arg.isspace():
             arg = Arg.parse(arg)
         return arg

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -6,10 +6,12 @@ objects, but all objects fall into one of the following three categories:
 
 import itertools
 import re
-from TexSoup.utils import CharToLineOffset, Token
+from TexSoup.utils import CharToLineOffset, Token, TC
 
-__all__ = ['TexNode', 'TexCmd', 'TexEnv', 'TexGroup', 'BracketGroup', 'BraceGroup', 'TexArgs',
-           'TexText', 'TexMathEnv', 'TexDisplayMathEnv', 'TexNamedEnv']
+__all__ = ['TexNode', 'TexCmd', 'TexEnv', 'TexGroup', 'BracketGroup',
+           'BraceGroup', 'TexArgs', 'TexText', 'TexMathEnv',
+           'TexDisplayMathEnv', 'TexNamedEnv', 'TexMathModeEnv',
+           'TexDisplayMathModeEnv']
 
 
 #############
@@ -894,11 +896,31 @@ class TexUnNamedEnv(TexEnv):
             contents, args, preserve_whitespace)
 
 
+class TexDisplayMathModeEnv(TexUnNamedEnv):
+
+    name = '$$'
+    begin = '$$'
+    end = '$$'
+    token_begin = TC.DisplayMathSwitch
+    token_end = TC.DisplayMathSwitch
+
+
+class TexMathModeEnv(TexUnNamedEnv):
+
+    name = '$'
+    begin = '$'
+    end = '$'
+    token_begin = TC.MathSwitch
+    token_end = TC.MathSwitch
+
+
 class TexDisplayMathEnv(TexUnNamedEnv):
 
     name = 'displaymath'
     begin = r'\['
     end = r'\]'
+    token_begin = TC.DisplayMathGroupStart
+    token_end = TC.DisplayMathGroupEnd
 
 
 class TexMathEnv(TexUnNamedEnv):
@@ -906,6 +928,8 @@ class TexMathEnv(TexUnNamedEnv):
     name = 'math'
     begin = r'\('
     end = r'\)'
+    token_begin = TC.MathGroupStart
+    token_end = TC.MathGroupEnd
 
 
 class TexCmd(TexExpr):

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -680,6 +680,14 @@ class TexExpr(object):
         >>> expr2 = TexExpr('textbf', ('\n', 'hi'), preserve_whitespace=True)
         >>> list(expr2.contents)
         ['\n', 'hi']
+        >>> expr = TexExpr('textbf', ('\n', 'hi'))
+        >>> expr.contents = ('hehe', '👻')
+        >>> list(expr.contents)
+        ['hehe', '👻']
+        >>> expr.contents = 35
+        Traceback (most recent call last):
+            ...
+        TypeError: Contents must be a string or iterable of strings
         """
         for content in self.all:
             if isinstance(content, TexText):

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -955,22 +955,29 @@ class TexText(TexExpr):
 class Arg(object):
     """Abstraction for a LaTeX expression argument.
 
-    >>> arg = Arg('huehue')
+    >>> arg = RArg('huehue')
     >>> arg[0]
     'h'
     >>> arg[1:]
     'uehue'
+    >>> arg2 = RArg(arg)
+    >>> arg2 == arg
+    True
     """
 
     fmt = "%s"
 
-    def __init__(self, *exprs):
+    def __new__(cls, *exprs):
         """Initialize argument using list of expressions.
 
         :param Union[str,TexCmd,TexEnv] exprs: Tex expressions contained in the
             argument. Can be other commands or environments, or even strings.
         """
-        self.contents = list(exprs)
+        if len(exprs) == 1 and isinstance(exprs[0], Arg):
+            return exprs[0]
+        arg = super(Arg, cls).__new__(cls)
+        arg.contents = list(exprs)
+        return arg
 
     def __eq__(self, other):
         return isinstance(other, Arg) and \

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -1097,6 +1097,8 @@ class BracketGroup(TexGroup):
     begin = '['
     end = ']'
     name = 'BracketGroup'
+    token_begin = TC.OpenBracket
+    token_end = TC.CloseBracket
 
 
 class BraceGroup(TexGroup):
@@ -1105,6 +1107,8 @@ class BraceGroup(TexGroup):
     begin = '{'
     end = '}'
     name = 'BraceGroup'
+    token_begin = TC.GroupStart
+    token_end = TC.GroupEnd
 
 
 arg_type = (BracketGroup, BraceGroup)

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -1057,33 +1057,19 @@ class TexGroup(TexUnNamedEnv):
         return '%s(%s)' % (self.__class__.__name__,
                            ', '.join(map(repr, self._contents)))
 
-    # TODO: should be moved to parser. Not supposed to be part of data
-    # structure
     @classmethod
     def parse(cls, s):
         """Parse a string or list and return an Argument object.
 
+        Naive implementation, does not parse expressions in provided string.
+
         :param Union[str,iterable] s: Either a string or a list, where the
             first and last elements are valid argument delimiters.
 
-        >>> TexGroup.parse(BraceGroup('arg0'))
-        BraceGroup('arg0')
         >>> TexGroup.parse('[arg0]')
         BracketGroup('arg0')
         """
-        if isinstance(s, arg_type):
-            return s
-        if isinstance(s, (list, tuple)):
-            for arg in arg_type:
-                if s[0] == arg.begin and s[-1] == arg.end:
-                    return arg(*s[1:-1])
-            raise TypeError(
-                'Malformed argument. First and last elements must '
-                'match a valid argument format. In this case, TexSoup'
-                ' could not find matching punctuation for: %s.\n'
-                'Common issues include: Unescaped special characters,'
-                ' mistyped closing punctuation, misalignment.' %
-                (str(s)))
+        assert isinstance(s, str)
         for arg in arg_type:
             if s.startswith(arg.begin) and s.endswith(arg.end):
                 return arg(s[len(arg.begin):-len(arg.end)])

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -46,10 +46,10 @@ def read_expr(src, skip_envs=(), context=None):
     c = next(src)
     # TODO: assemble and use groups
     if c.category == TC.MathSwitch:
-        expr = TexEnv(c, [], nobegin=True)
+        expr = TexEnv(c, begin=c, end=c, contents=[])
         return read_math_env(src, expr)
     elif c.category == TC.MathGroupStart:
-        if c.startswith(TexDisplayMathEnv.start()):
+        if c.startswith(TexDisplayMathEnv.begin):
             expr = TexDisplayMathEnv([])
         else:
             expr = TexMathEnv([])
@@ -63,7 +63,7 @@ def read_expr(src, skip_envs=(), context=None):
         elif command == 'begin':
             # allow whitespace TODO: should be built into command tokenization
             forward_until_non_whitespace(src)
-            mode, expr, _ = 'begin', TexEnv(src.peek(1)), src.forward(3)
+            mode, expr, _ = 'begin', TexNamedEnv(src.peek(1)), src.forward(3)
         else:
             mode, expr = 'command', TexCmd(command)
 

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -25,7 +25,7 @@ def read_tex(buf, skip_envs=()):
     :return: Iterable[TexExpr]
     """
     buf = Buffer(read_exprs(buf, read_skip, skip_envs=skip_envs))
-    buf = MixedBuffer(read_exprs(buf, read_expr, skip_envs=skip_envs))
+    buf = MixedBuffer(read_exprs(buf, read_expr))
     buf = read_exprs(buf, wrap_expr)
     return buf
 
@@ -40,6 +40,7 @@ def read_skip(src, skip_envs=()):
 
     :param Buffer src: a buffer of tokens
     :param Tuple[str] skip_envs: environments to skip parsing
+    :return: Token
     """
     c = next(src)
     position = src.position  # grab position before advancing buffer
@@ -83,7 +84,6 @@ def read_expr(src, context=None):
         elif command == 'begin':
             # allow whitespace TODO: should be built into command tokenization
             forward_until_non_whitespace(src)
-            assert src.peek(1) not in skip_envs
             mode, expr, _ = 'begin', TexNamedEnv(src.peek(1)), src.forward(3)
         else:
             mode, expr = 'command', TexCmd(command)
@@ -91,7 +91,7 @@ def read_expr(src, context=None):
         expr.args = read_args(src, expr.args)
 
         if mode == 'begin':
-            read_env(src, expr, skip_envs=skip_envs)
+            read_env(src, expr)
         return expr
     if c.category == TC.OpenBracket and isinstance(context, TexArgs) or \
             c.category == TC.GroupStart:

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -156,8 +156,9 @@ def unclosed_env_handler(src, expr, end):
     """
     clo = CharToLineOffset(str(src))
     explanation = 'Instead got %s' % end if end else 'Reached end of file.'
+    line, offset = clo(src.position)
     raise EOFError('[Line: %d, Offset: %d] "%s" env expecting %s. %s' % (
-        *clo(src.position), expr.name, expr.end, explanation))
+        line, offset, expr.name, expr.end, explanation))
 
 
 def read_math_env(src, expr):

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -225,6 +225,17 @@ def read_env(src, expr):
     :param Buffer src: a buffer of tokens
     :param TexExpr expr: expression for the environment
     :rtype: TexExpr
+
+    >>> from TexSoup.category import categorize
+    >>> from TexSoup.tokens import tokenize
+    >>> buf = tokenize(categorize(' tingtang \\end\n{foobar}walla'))
+    >>> read_env(buf, TexNamedEnv('foobar'))
+    TexNamedEnv('foobar', [' tingtang '], [])
+    >>> buf = tokenize(categorize(' tingtang \\end\n\n{foobar}walla'))
+    >>> read_env(buf, TexNamedEnv('foobar')) #doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    EOFError: [Line: 0, Offset: 1] ...
     """
     contents = []
     while src.hasNext():
@@ -233,7 +244,7 @@ def read_env(src, expr):
             if name == 'end':
                 break
         contents.append(read_expr(src))
-    if not src.hasNext() or args[0].string != expr.name:
+    if not src.hasNext() or not args or args[0].string != expr.name:
         unclosed_env_handler(src, expr, src.peek((0, 6)))
     src.forward(5)
     expr.append(*contents)

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -240,7 +240,7 @@ def read_arg(src, c):
     :param Buffer src: a buffer of tokens
     :param str c: argument token (starting token)
     :return: the parsed argument
-    :rtype: Arg
+    :rtype: TexGroup
     """
     content = [c]
     while src.hasNext():
@@ -249,4 +249,4 @@ def read_arg(src, c):
             break
         else:
             content.append(read_expr(src))
-    return Arg.parse(content)
+    return TexGroup.parse(content)

--- a/TexSoup/tex.py
+++ b/TexSoup/tex.py
@@ -17,4 +17,4 @@ def read(tex, skip_envs=()):
     buf = categorize(tex)
     buf = tokenize(buf)
     buf = read_tex(buf, skip_envs=skip_envs)
-    return TexEnv('[tex]', buf), tex
+    return TexEnv('[tex]', begin='', end='', contents=buf), tex

--- a/TexSoup/tex.py
+++ b/TexSoup/tex.py
@@ -12,11 +12,11 @@ def read(tex, skip_envs=()):
     :param Union[str,iterable] tex: LaTeX source
     :return TexEnv: the global environment
     """
-    if isinstance(tex, str):
-        tex = tex
-    else:
+    if not isinstance(tex, str):
         tex = ''.join(itertools.chain(*tex))
-    buf, children = tokenize(categorize(tex)), []
+    buf = categorize(tex)
+    buf = tokenize(buf)
+    children = []
     while buf.hasNext():
         children.append(read_tex(buf, skip_envs=skip_envs))
     return TexEnv('[tex]', children), tex

--- a/TexSoup/tex.py
+++ b/TexSoup/tex.py
@@ -1,4 +1,4 @@
-from TexSoup.reader import read_tex
+from TexSoup.reader import read_expr, read_tex
 from TexSoup.data import *
 from TexSoup.utils import *
 from TexSoup.tokens import tokenize
@@ -16,7 +16,5 @@ def read(tex, skip_envs=()):
         tex = ''.join(itertools.chain(*tex))
     buf = categorize(tex)
     buf = tokenize(buf)
-    children = []
-    while buf.hasNext():
-        children.append(read_tex(buf, skip_envs=skip_envs))
-    return TexEnv('[tex]', children), tex
+    buf = read_tex(buf, skip_envs=skip_envs)
+    return TexEnv('[tex]', buf), tex

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -12,11 +12,6 @@ import itertools
 import string
 
 
-# Core category codes
-# https://www.overleaf.com/learn/latex/Table_of_TeX_category_codes
-END_OF_LINE_TOKENS  = ('\n', '\r')
-
-
 # Only includes items that cannot cause failures
 TC = IntEnum('TokenCode', (
     'Escape',

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -11,10 +11,6 @@ from TexSoup.utils import IntEnum, TC
 import itertools
 import string
 
-
-ARG_START_TOKENS = [TC.OpenBracket, TC.GroupStart]
-ARG_END_TOKENS = [TC.CloseBracket, TC.GroupEnd]
-
 # TODO: misnomer, what does ALL_TOKENS actually contain?
 ALL_TOKENS = ('\\', '{', '[', ']', '}', '%', r'\[', r'\(', r'\]', r'\)', '$', '$$')
 

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -39,6 +39,8 @@ TC = IntEnum('TokenCode', (
     # temporary (Replace with macros support)
     'PunctuationCommandName',
     'SizeCommand',
+    'Spacer',
+    'Skip',
 ), start=max(CC))
 
 
@@ -286,7 +288,8 @@ def tokenize_symbols(text, prev=None):
         CC.OpenBracket:     TC.OpenBracket,
         CC.CloseBracket:    TC.CloseBracket,
         CC.OpenParen:       TC.OpenParen,
-        CC.CloseParen:      TC.CloseParen
+        CC.CloseParen:      TC.CloseParen,
+        # CC.Spacer:          TC.Spacer
     }
     if text.peek().category in mapping.keys():
         result = text.forward(1)

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -186,7 +186,7 @@ def tokenize_line_comment(text, prev=None):
     >>> _ = next(b), next(b)
     >>> tokenize_line_comment(b)
     '%'
-    >>> tokenize_line_comment(categorize('\%'))
+    >>> tokenize_line_comment(categorize(r'\%'))
     """
     result = Token('', text.position)
     if text.peek().category == CC.Comment and (

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -12,15 +12,11 @@ import itertools
 import string
 
 
-# Supersets of category codes
-MATH_START_TOKENS = (r'\[', r'\(')  # TODO: how to do this cleanly?
-MATH_END_TOKENS = (r'\]', r'\)')
-
 ARG_START_TOKENS = [TC.OpenBracket, TC.GroupStart]
 ARG_END_TOKENS = [TC.CloseBracket, TC.GroupEnd]
 
 # TODO: misnomer, what does ALL_TOKENS actually contain?
-ALL_TOKENS = ('\\', '{', '[', ']', '}', '%',) + MATH_START_TOKENS + MATH_END_TOKENS + ('$', '$$')
+ALL_TOKENS = ('\\', '{', '[', ']', '}', '%', r'\[', r'\(', r'\]', r'\)', '$', '$$')
 
 # Custom higher-level combinations of primitives
 SKIP_ENVS = ('verbatim', 'equation', 'lstlisting', 'align', 'alignat',

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -237,16 +237,6 @@ class Token(str):
             start = len(self.text) + start
         return Token(self.text[i], self.position + start, self.category)
 
-    def split(self, sep=None, maxsplit=-1):
-        result = []
-        split_res = self.text.split(sep=sep, maxsplit=maxsplit)
-        txt = self.text
-        cur_offset = 0
-        for s in split_res:
-            cur_offset = txt.find(s, cur_offset)
-            result.append(Token(s, self.position + cur_offset, self.category))
-        return result
-
     def strip(self, *args, **kwargs):
         stripped = self.text.strip(*args, **kwargs)
         offset = self.text.find(stripped)

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -376,7 +376,7 @@ class Buffer:
         self.__i -= j
         return self[self.__i:self.__i + j]
 
-    def peek(self, j=(0, 1)):
+    def peek(self, j=0):
         """Peek at the next value(s), without advancing the Buffer.
 
         Return None if index is out of range.
@@ -477,6 +477,10 @@ class MixedBuffer(Buffer):
 
         :param iterator: iterator or iterable
         :param func join: function to join multiple buffer elements
+
+        >>> buf = MixedBuffer([324, 'adsf', lambda x: x])
+        >>> buf.peek()
+        324
         """
         super().__init__(iterator,
             join=lambda x: x, empty=lambda x: [],

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -510,13 +510,3 @@ def to_buffer(convert_in=True, convert_out=True, Buffer=Buffer):
             return output
         return wrap
     return decorator
-
-
-def to_mixed_buffer(convert_in=True, convert_out=True):
-    """Decorator converting all strings and iterators/iterables into Mixed
-    Buffers.
-
-    :param bool convert_in: Convert inputs where applicable to Buffers
-    :param bool convert_out: Convert output to a Buffer
-    """
-    return to_buffer(convert_in, convert_out, Buffer=MixedBuffer)

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -68,8 +68,7 @@ TC = IntEnum('TokenCode', (
     # temporary (Replace with macros support)
     'PunctuationCommandName',
     'SizeCommand',
-    'Spacer',
-    'Skip',
+    'Spacer'
 ), start=max(CC))
 
 

--- a/TexSoup/utils.py
+++ b/TexSoup/utils.py
@@ -43,6 +43,36 @@ CC = IntEnum('CategoryCodes', (
 ))
 
 
+# Only includes items that cannot cause failures
+TC = IntEnum('TokenCode', (
+    'Escape',
+    'GroupStart',
+    'GroupEnd',
+    'Comment',
+    'MergedSpacer',  # whitespace allowed between <command name> and arguments
+    'EscapedComment',
+    'MathSwitch',
+    'DisplayMathSwitch',
+    'MathGroupStart',
+    'MathGroupEnd',
+    'DisplayMathGroupStart',
+    'DisplayMathGroupEnd',
+    'LineBreak',
+    'CommandName',
+    'Text',
+    'OpenBracket',
+    'CloseBracket',
+    'OpenParen',
+    'CloseParen',
+
+    # temporary (Replace with macros support)
+    'PunctuationCommandName',
+    'SizeCommand',
+    'Spacer',
+    'Skip',
+), start=max(CC))
+
+
 class Token(str):
     """Enhanced string object with knowledge of global position."""
 
@@ -300,9 +330,9 @@ class Buffer:
         self.__empty = empty
 
     # noinspection PyPep8Naming
-    def hasNext(self):
+    def hasNext(self, n=1):
         """Returns whether or not there is another element."""
-        return bool(self.peek())
+        return bool(self.peek(n - 1))
 
     def startswith(self, s):
         """Check if iterator starts with s, beginning from the current

--- a/examples/list_everything.py
+++ b/examples/list_everything.py
@@ -28,7 +28,7 @@ def everything(tex_tree):
             result.append(["\\" + tex_code.name + str(tex_code.args)])
         elif isinstance(tex_code, TexSoup.TexText):
             result.append(tex_code.text)
-        elif isinstance(tex_code, TexSoup.Arg):
+        elif isinstance(tex_code, TexSoup.TexGroup):
             result.append(["{", everything(TexSoup.TexSoup(tex_code.value).expr.all), "}"])
         else:
             result.append([str(tex_code)])

--- a/examples/simple_conversion.py
+++ b/examples/simple_conversion.py
@@ -34,7 +34,7 @@ def to_dictionary(tex_tree):
             str_tree.append({i.name: "\\" + i.name + str(i.args)})
         elif isinstance(i, TexSoup.TexText):
             str_tree.append(str(i.text))
-        elif isinstance(i, TexSoup.Arg):
+        elif isinstance(i, TexSoup.TexGroup):
             str_tree.append(["{", to_dictionary(TexSoup.TexSoup(i.value).expr.all), "}"])
         else:
             str_tree.append(str(i))

--- a/examples/structure_diagram.py
+++ b/examples/structure_diagram.py
@@ -26,7 +26,7 @@ def tex_read(tex_soup, prefix=" |- "):
             result += textwrap.indent("\\" + tex_code.name + str(tex_code.args), prefix, lambda line: True)
         elif isinstance(tex_code, TexSoup.TexText):
             result += textwrap.indent(tex_code.text.strip(), prefix, lambda line: True)
-        elif isinstance(tex_code, TexSoup.Arg):
+        elif isinstance(tex_code, TexSoup.TexGroup):
             result += tex_read((prefix + "{" + "\n"
                                 + textwrap.indent(tex_read(TexSoup.TexSoup(tex_code.value).expr.all), "\t")
                                 + "\n" + prefix + "}").splitlines(), prefix="")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -295,6 +295,22 @@ def test_comment_after_escape():
     hi\\%""")
     assert len(list(soup2.document.contents)) == 3
 
+    soup3 = TexSoup(r"""
+    \documentclass{article}
+    \usepackage{graphicx}
+    \begin{document}
+    \begin{equation}
+    \scalebox{2.0}{$x =
+    \begin{cases}
+    1, & \text{if } y=1 \\
+    0, & \text{otherwise}
+    \end{cases}$}
+    \end{equation}
+    \end{document}
+    """)
+    assert soup3.equation
+    assert soup3.scalebox
+
 
 def test_items_with_labels():
     """Items can have labels with square brackets such as in the description

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -316,6 +316,14 @@ def test_nested_commands():
     assert len(list(soup.emph.contents)) == 3
 
 
+def test_def_item():
+    """Tests that def with more 'complex' argument + item body parses."""
+    soup = TexSoup(r"""
+    \def\itemeqn{\item\abovedisplayskip=2pt\abovedisplayshortskip=0pt~\vspace*{-\baselineskip}}
+    """)
+    assert soup.item is not None
+
+
 ##############
 # FORMATTING #
 ##############
@@ -485,7 +493,7 @@ def test_arg_parse():
     """Test arg parsing errors."""
     from TexSoup.data import TexGroup
     with pytest.raises(TypeError):
-        TexGroup.parse(('{', ']'))
+        TexGroup.parse('{]')
 
     with pytest.raises(TypeError):
         TexGroup.parse('\section[{')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -274,6 +274,28 @@ def test_comment_unparsed():
     assert '%' not in str(soup.caption)
 
 
+def test_comment_after_escape():
+    """Tests that comments after escapes work."""
+    soup = TexSoup(r"""\documentclass{article}
+    \begin{document}
+     \\%
+    \end{document}
+    """)
+    assert len(list(soup.document.contents)) == 2
+
+    soup2 = TexSoup(r"""\documentclass{article}
+    \begin{document}
+
+    hi\\%
+
+
+    there
+
+    \end{document}
+    hi\\%""")
+    assert len(list(soup2.document.contents)) == 3
+
+
 def test_items_with_labels():
     """Items can have labels with square brackets such as in the description
     environment. See Issue #32."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -486,9 +486,9 @@ def test_unclosed_math_environments():
 
 def test_arg_parse():
     """Test arg parsing errors."""
-    from TexSoup.data import Arg
+    from TexSoup.data import TexGroup
     with pytest.raises(TypeError):
-        Arg.parse(('{', ']'))
+        TexGroup.parse(('{', ']'))
 
     with pytest.raises(TypeError):
-        Arg.parse('\section[{')
+        TexGroup.parse('\section[{')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -367,7 +367,8 @@ def test_math_environment_escape():
     """Tests $ escapes in math environment."""
     soup = TexSoup(r"$ \$ $")
     contents = list(soup.contents)
-    assert r'\$' in contents[0][0], 'Dollar sign not escaped!'
+    assert r'\$' in contents[0][0], \
+        'Dollar sign not escaped! Contents: %s' % contents
 
 
 def test_punctuation_command_structure():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -71,10 +71,6 @@ def test_commands_envs_text():
     assert len(contents) == 6
     everything = list(doc.expr.all)
     assert len(everything) == 12
-    # arguments = str(doc.section.expr.arguments)
-    # assert arguments == "\n    [Tales]{Chikin Tales}"
-    # arguments_list = [str(arg) for arg in doc.section.expr.arguments]
-    # assert arguments_list == ['\n    ', '[Tales]', '{Chikin Tales}']
 
 
 #########


### PR DESCRIPTION
Major refactoring for parsing:

- Stricter abstraction, dependence on tokens without accessing string values
- More advanced / robust parsing for commands and environments w.r.t. whitespace
- Resolves several outstanding parse issues
- Subsumes #78 

This means all of the following examples can be parsed.
```
\begin
{itemize}
\item hello] there[
\end
{itemize}
```
```
\somecommand
{[}

{]}
```