### PR TITLE
It's contents not content, and all is only on expr not on nodes

### DIFF
--- a/docs/source/navigation.rst
+++ b/docs/source/navigation.rst
@@ -67,8 +67,8 @@ Note that changing this list in-place will not affect the environment::
 There are several views into an environment's content:
 
 - :code:`.children`: Nested Tex expressions. Does not include floating text.
-- :code:`.content`: Nested Tex expressions and text. Does not contain whitespace-only text.
-- :code:`.all`: Nested Tex expressions and text, regardless of whitespace or not. All information needed to reconstruct the original source.
+- :code:`.contents`: Nested Tex expressions and text. Does not contain whitespace-only text.
+- :code:`.expr.all`: Nested Tex expressions and text, regardless of whitespace or not. All information needed to reconstruct the original source.
 - :code:`.descendants`: Tex expressions nested inside of Tex expressions.
 - :code:`.text`: Used to "detex" a source file. Returns text from all descendants, without Tex expressions.
 


### PR DESCRIPTION
I noticed these two small typos in the docs.

__________

Also, I noticed a surprising aspect of `.contents` including optional args of environments, e.g.

```python
>>> figs = soup.find_all('figure')
>>> fig = figs[0]
>>> fig
\begin{figure}[H]
	\centering
	\includegraphics[width=0.4\textwidth]{figures/vectors/vector_components.pdf}
	\vspace{-2mm}
	\caption{	The vector $\vec{v}=(3,2)$ is an arrow in the Cartesian plane.
			The horizontal component of $\vec{v}$ is $v_x=3$
			and the vertical component  is $v_y=2$.}
	\label{fig:vector_components}
\end{figure}


>>> fig.contents
['H',
 \centering,
 \includegraphics[width=0.4\textwidth]{figures/vectors/vector_components.pdf},
 \vspace{-2mm},
 \caption{	The vector $\vec{v}=(3,2)$ is an arrow in the Cartesian plane.
 			The horizontal component of $\vec{v}$ is $v_x=3$
 			and the vertical component  is $v_y=2$.},
 \label{fig:vector_components}]
```
I would have expected the "[H]" not to be part of the content stream since it is logically part of the environment opening tag, but as you can above the first item in contents is an `H` of type TexSoup.utils.Token.

Note figure-environment has correctly parsed the `[H]` optional arg:
```python
>>> fig.args
[BracketGroup('H')]
```
so wondering why if it should be removed from the `.contents` stream. Let me know if this is as intended, or if I should file a bug.

