### PR TITLE
Punctuation commands fix (Issue #111)

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -29,7 +29,10 @@ ARG_BEGIN_TO_ENV = {arg.token_begin: arg for arg in arg_type}
 SIGNATURES = {
     'def': (2, 0),
     'textbf': (1, 0),
-    'section': (1, 1)
+    'section': (1, 1),
+    'label': (1, 0),
+    'cup': (0, 0),
+    'noindent': (0, 0),
 }
 
 

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -12,7 +12,7 @@ import itertools
 import string
 
 # Custom higher-level combinations of primitives
-SKIP_ENV_NAMES = ('lstlisting', 'verbatim')
+SKIP_ENV_NAMES = ('lstlisting', 'verbatim', 'verbatimtab', 'Verbatim', 'listing')
 MATH_ENV_NAMES = (
     'align', 'align*', 'alignat', 'array', 'displaymath', 'eqnarray',
     'eqnarray*', 'equation', 'equation*', 'flalign', 'flalign*', 'gather',
@@ -20,7 +20,7 @@ MATH_ENV_NAMES = (
 )
 BRACKETS_DELIMITERS = {
     '(', ')', '<', '>', '[', ']', '{', '}', r'\{', r'\}', '.' '|', r'\langle',
-    r'\rangle', r'\lfloor', '\rfloor', r'\lceil', r'\rceil', r'\ulcorner',
+    r'\rangle', r'\lfloor', r'\rfloor', r'\lceil', r'\rceil', r'\ulcorner',
     r'\urcorner', r'\lbrack', r'\rbrack'
 }
 # TODO: looks like left-right do have to match

--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -303,7 +303,7 @@ def tokenize_punctuation_command_name(text, prev=None):
     if text.peek(-1) and text.peek(-1).category == CC.Escape:
         for point in PUNCTUATION_COMMANDS:
             if text.peek((0, len(point))) == point:
-                result = text.forward(len(point) + 1)
+                result = text.forward(len(point))
                 result.category = TC.PunctuationCommandName
                 return result
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,7 +36,6 @@ def test_navigation_children(chikin):
 
 def test_navigation_descendants(chikin):
     """Test identification of all descendants"""
-    print(list(chikin.descendants))
     assert len(list(chikin.descendants)) == 28
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -211,6 +211,29 @@ def test_math_environment_weirdness():
     assert '$' in str(soup.env), 'Math env not correctly parsed after \\\\'
 
 
+def test_tokenize_punctuation_command_names():
+    """Tests handling math expressions including bracket modifiers."""
+    # GH111 size variant
+    soup = TexSoup(r"""$\big(xy\big)$""")
+    assert str(list(soup.descendants)[1]) == r'\big(', 'wrong punctuation mark'
+    assert str(list(soup.descendants)[3]) == r'\big)', 'wrong punctuation mark'
+    # GH111 left-right variant
+    soup = TexSoup(r"""$\left[xy\right]$""")
+    assert str(list(soup.descendants)[1]) == r'\left[', 'wrong punctuation mark'
+    assert str(list(soup.descendants)[3]) == r'\right]', 'wrong punctuation mark'
+    # one sided
+    soup = TexSoup(r"""$\Big|$""")
+    assert str(list(soup.descendants)[1]) == r'\Big|', 'wrong punctuation'
+    # set builder
+    soup = TexSoup(r"""$\left\{x|y\right\}$""")
+    assert str(list(soup.descendants)[1]) == r'\left\{', 'wrong punctuation'
+    assert str(list(soup.descendants)[3]) == r'\right\}', 'wrong punctuation'
+    # long ones
+    soup = TexSoup(r"""$\big\lfloor x \big\rfloor$""")
+    assert str(list(soup.descendants)[1]) == r'\big\lfloor', 'wrong punctuation'
+    assert str(list(soup.descendants)[3]) == r'\big\rfloor', 'wrong punctuation'
+
+
 def test_item_parsing():
     """Tests that item parsing is valid."""
     soup = TexSoup(r"""\item aaa {\bbb} ccc""")


### PR DESCRIPTION
> @alvinwan said:
> Is it maybe because of the following line? (maybe should be len(point)?
> `result = text.forward(len(point) + 1) `

Yes indeed. After this change `PunctuationCommandName`s no longer "gobble" the following charaacter and seem to behave as expected.

I've added some tests (if tokens serialize back to string correctly, then they must have been tokenized together as a unit). By coincidence I happened to choose a delimiter `\rfloor` and test was failing... so we ended up with a bonus typo fix.

Last but not least I added three more verbatim-type environments (users can manually add those to `skip_envs` if needed, but seems like a good idea to have them "baked in").