### PR TITLE
Fix parsing of `\def` without braces around new command name

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -1317,7 +1317,7 @@ class TexArgs(list):
         """
         arg = self.__coerce(arg)
 
-        if isinstance(arg, TexGroup):
+        if isinstance(arg, (TexGroup, TexCmd)):
             super().insert(i, arg)
 
         if len(self) <= 1:

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -416,21 +416,20 @@ def read_arg_required(
     while n_required != 0 and src.hasNext():
         spacer = read_spacer(src)
 
-        if src.hasNext();
-            if src.peek().category == TC.GroupBegin:
-                args.append(read_arg(
-                    src, next(src), tolerance=tolerance, mode=mode))
-                n_required -= 1
-                continue
+        if src.hasNext() and src.peek().category == TC.GroupBegin:
+            args.append(read_arg(
+                src, next(src), tolerance=tolerance, mode=mode))
+            n_required -= 1
+            continue
+        elif src.hasNext() and n_required > 0:
+            next_token = next(src)
+            if next_token.category == TC.Escape:
+                name, _ = read_command(src, 0, 0, tolerance=tolerance, mode=mode)
+                args.append(TexCmd(name, position=next_token.position))
             else:
-                next_token = next(src)
-                if first_token.category == TC.Escape:
-                    name, _ = read_command(src, 0, 0, tolerance=tolerance, mode=mode)
-                    args.append(TexCmd(name, position=next_token.position))
-                else:
-                    args.append('{%s}' % next_token)
-                n_required -= 1
-                continue
+                args.append('{%s}' % next_token)
+            n_required -= 1
+            continue
 
         if spacer:
             src.backward(1)

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -416,20 +416,21 @@ def read_arg_required(
     while n_required != 0 and src.hasNext():
         spacer = read_spacer(src)
 
-        if src.hasNext() and src.peek().category == TC.GroupBegin:
-            args.append(read_arg(
-                src, next(src), tolerance=tolerance, mode=mode))
-            n_required -= 1
-            continue
-        elif src.hasNext() and n_required > 0:
-            first_token = next(src)
-            arg_string = str(first_token)
-            if src.hasNext() and first_token.category == TC.Escape:
-                second_token = next(src)
-                arg_string += str(second_token)
-            args.append('{%s}' % arg_string)
-            n_required -= 1
-            continue
+        if src.hasNext();
+            if src.peek().category == TC.GroupBegin:
+                args.append(read_arg(
+                    src, next(src), tolerance=tolerance, mode=mode))
+                n_required -= 1
+                continue
+            else:
+                next_token = next(src)
+                if first_token.category == TC.Escape:
+                    name, _ = read_command(src, 0, 0, tolerance=tolerance, mode=mode)
+                    args.append(TexCmd(name, position=next_token.position))
+                else:
+                    args.append('{%s}' % next_token)
+                n_required -= 1
+                continue
 
         if spacer:
             src.backward(1)

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -391,7 +391,7 @@ def read_arg_required(
        b. A curly-brace delimiter. If the required argument is brace-delimited,
           the contents of the brace group are used as the argument.
        c. Spacer or not, if a brace group is not found, simply use the next
-          character.
+          character, unless it is a backslash, in which case use the full command name
 
     :param Buffer src: a buffer of tokens
     :param TexArgs args: existing arguments to extend
@@ -422,7 +422,12 @@ def read_arg_required(
             n_required -= 1
             continue
         elif src.hasNext() and n_required > 0:
-            args.append('{%s}' % next(src))
+            first_token = next(src)
+            arg_string = str(first_token)
+            if src.hasNext() and first_token.category == TC.Escape:
+                second_token = next(src)
+                arg_string += str(second_token)
+            args.append('{%s}' % arg_string)
             n_required -= 1
             continue
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -388,8 +388,8 @@ def test_def_without_braces():
     """Tests that def without braces around the new command parses correctly"""
     soup = TexSoup(r"\def\acommandname{replacement text}")
     assert len(soup.find("def").args) == 2
-    assert soup.find("def").args[0].string == r"\acommandname"
-    assert soup.find("def").args[1].string == "replacement text"
+    assert str(soup.find("def").args[0]) == r"\acommandname"
+    assert str(soup.find("def").args[1]) == "{replacement text}"
 
 
 def test_grouping_optional_argument():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -384,6 +384,14 @@ def test_def_item():
     assert soup.item is not None
 
 
+def test_def_without_braces():
+    """Tests that def without braces around the new command parses correctly"""
+    soup = TexSoup(r"\def\acommandname{replacement text}")
+    assert len(soup.find("def").args) == 2
+    assert soup.find("def").args[0].string == r"\acommandname"
+    assert soup.find("def").args[1].string == "replacement text"
+
+
 def test_grouping_optional_argument():
     """Tests that grouping occurs correctly"""
     soup = TexSoup(r"\begin{Theorem}[The argopt contains {$]\int_\infty$} the square bracket]\end{Theorem}")


### PR DESCRIPTION
Resolves #118 and #131.

This is the current behavior on `master`:

```python
>>> TexSoup.TexSoup(r'\def\foo{bar}')
\def{\}{foo}{bar}
```

It interprets the `\` alone as the first argument, which escapes the brace afterwards and the resulting code will fail with a runaway definition error.

With this patch, I get:

```python
>>> TexSoup.TexSoup(r'\def\foo{bar}')
\def{\foo}{bar}
```

It doesn't quite reproduce the original source, but it will at least render as intended. It also doesn't handle cases of `\def` for commands that take arguments like `\def\foo#1{bar #1}`, but it at least doesn't do any worse than how those are currently handled.