### PR TITLE
Keep control spaces

### DIFF
--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -116,14 +116,15 @@ def tokenize_escaped_symbols(text, prev=None):
     '\\}'
     >>> tokenize_escaped_symbols(categorize(r'\%'))
     '\\%'
-    >>> tokenize_escaped_symbols(categorize(r'\ %'))  # not even one spacer is allowed
+    >>> tokenize_escaped_symbols(categorize(r'\ '))
+    '\\ '
     """
     if text.peek().category == CC.Escape \
             and text.peek(1) \
             and text.peek(1).category in (
                 CC.Escape, CC.GroupBegin, CC.GroupEnd, CC.MathSwitch,
                 CC.Alignment, CC.Macro, CC.Superscript, CC.Subscript,
-                CC.Active, CC.Comment, CC.Other):
+                CC.Spacer, CC.Active, CC.Comment, CC.Other):
         result = text.forward(2)
         result.category = TC.EscapedComment
         return result

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -189,9 +189,9 @@ def test_escaped_characters():
     """
     soup = TexSoup(r"""
     \begin{itemize}
-    \item Ice cream costs \$4-\$5 around here. \}[\{]
+    \item Ice cream costs \$4-\$5 around here. \}\ [\{]
     \end{itemize}""")
-    assert str(soup.item).strip() == r'\item Ice cream costs \$4-\$5 around here. \}[\{]'
+    assert str(soup.item).strip() == r'\item Ice cream costs \$4-\$5 around here. \}\ [\{]'
     assert '\\$4-\\$5' in str(soup), 'Escaped characters not properly rendered.'
 
 


### PR DESCRIPTION
Resolves #117.

Retain control spaces (`'\ '`), as they change the meaning of the code. For example, some initially valid TeX:

```python
>>> TexSoup.TexSoup(r'\ foo')
\foo
```

becomes an undefined control sequence. With this PR, you get:

```python
>>> TexSoup.TexSoup(r'\ foo')
\ foo
```