### PR TITLE
Add/fix some zero-argument signatures

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -31,7 +31,11 @@ SIGNATURES = {
     'textbf': (1, 0),
     'section': (1, 1),
     'label': (1, 0),
+    'cap': (0, 0),
     'cup': (0, 0),
+    'in': (0, 0),
+    'notin': (0, 0),
+    'infty': (0, 0),
     'noindent': (0, 0),
 }
 

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -282,7 +282,7 @@ def read_env(src, expr, skip_envs=(), tolerance=0, mode=MODE_NON_MATH):
     while src.hasNext():
         if src.peek().category == TC.Escape:
             name, args = make_read_peek(read_command)(
-                src, 1, skip=1, tolerance=tolerance, mode=mode)
+                src, skip=1, tolerance=tolerance, mode=mode)
             if name == 'end':
                 break
         contents.append(read_expr(src, skip_envs=skip_envs, tolerance=tolerance, mode=mode))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -385,7 +385,7 @@ def test_def_item():
 
 
 def test_def_without_braces():
-    """Tests that def without braces around the new command parses correctly"""
+    """Tests that def without braces around the new command parses correctly."""
     soup = TexSoup(r"\def\acommandname{replacement text}")
     assert len(soup.find("def").args) == 2
     assert str(soup.find("def").args[0]) == r"\acommandname"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -398,6 +398,16 @@ def test_grouping_optional_argument():
     assert len(soup.Theorem.args) == 1
 
 
+def test_zero_argument_signatures():
+    """Tests that specific commands that do not take arguments are parsed correctly."""
+    soup = TexSoup(r"$\cap[\cup[\in[\notin[\infty[$")
+    assert len(soup.find("cap").args) == 0
+    assert len(soup.find("cup").args) == 0
+    assert len(soup.find("in").args) == 0
+    assert len(soup.find("notin").args) == 0
+    assert len(soup.find("infty").args) == 0
+
+
 ##############
 # FORMATTING #
 ##############

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -407,6 +407,9 @@ def test_zero_argument_signatures():
     assert len(soup.find("notin").args) == 0
     assert len(soup.find("infty").args) == 0
 
+    soup = TexSoup(r"\begin{equation} \cup [0, \infty) \end{equation}")
+    assert len(soup.find("cup").args) == 0
+
 
 ##############
 # FORMATTING #


### PR DESCRIPTION
Adds `SIGNATURES` entries for a few common commands that don't take arguments, as suggested by @ivanistheone in multiple issues. Also fixes the fact that these rules are currently ignored inside of named environments (e.g., `equation`).

Resolves #115, resolves #126, resolves #137.