### PR TITLE
Properly handle `delete` when in an argument

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -467,16 +467,11 @@ class TexNode(object):
         \textit{keep me!}
         """
 
-        # TODO: needs better abstraction for supports contents
-        parent = self.parent
-        if parent.expr._supports_contents():
-            parent.remove(self)
-            return
-
-        # TODO: needs abstraction for removing from arg
-        for arg in parent.args:
-            if self.expr in arg.contents:
-                arg._contents.remove(self.expr)
+        for arg in self.parent.args:
+            if self in arg.contents:
+                arg.remove(self)
+                return
+        self.parent.remove(self)
 
     def find(self, name=None, **attrs):
         r"""First descendant node matching criteria.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,6 +100,12 @@ def test_delete_arg():
     soup.bar.delete()
 
 
+def test_delete_env_arg():
+    """Delete an element from an environment arg in the parse tree"""
+    soup = TexSoup(r'\begin{foo}{\bar{\baz}}\end{foo}')
+    soup.bar.delete()
+
+
 def test_delete_token():
     """Delete Token"""
     soup = TexSoup(r"""


### PR DESCRIPTION
Try to remove from `parent.args` before defaulting to removing from `parent._contents`. Resolves #146.