### PR TITLE
Fix parsing of environments inside special commands

### DIFF
--- a/TexSoup/tokens.py
+++ b/TexSoup/tokens.py
@@ -18,6 +18,7 @@ MATH_ENV_NAMES = (
     'eqnarray*', 'equation', 'equation*', 'flalign', 'flalign*', 'gather',
     'gather*', 'math', 'multline', 'multline*', 'split'
 )
+SPECIAL_COMMANDS = {'newcommand', 'renewcommand', 'providecommand'}
 BRACKETS_DELIMITERS = {
     '(', ')', '<', '>', '[', ']', '{', '}', r'\{', r'\}', '.' '|', r'\langle',
     r'\rangle', r'\lfloor', r'\rfloor', r'\lceil', r'\rceil', r'\ulcorner',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -629,3 +629,22 @@ def test_tolerance_env_unclosed():
     \end{envb}""", tolerance=1)
     assert len(list(soup.enva.contents)) == 1
     assert soup.end
+
+def test_special_command():
+    """Test that we tolerate unclosed environments when in special mode."""
+    # source:
+    # https://github.com/alvinwan/TexSoup/issues/135#issuecomment-1705749106
+    texsrc = r"""
+    \documentclass[useAMS,usenatbib]{mnras}
+    \newcommand{\beq}{\begin{equation}}
+    \newcommand{\eeq}{\end{equation}}
+
+    \begin{document}
+    \begin{itemize}
+    \item something
+    \end{itemize}
+
+    \end{document}
+    """
+    soup = TexSoup(texsrc)
+    assert soup


### PR DESCRIPTION
Fixes #135.
When using "special" commands (like `\newcommand`), it's possible to define only one part of an environment (like a singular `\begin{equation}`), which caused errors when parsing. This commit implements a "special" mode, which is entered every time a "special" command is encountered (for now, `\newcommand`, `\renewcommand`, and `\providecommand`), which disables the matching of `\begin{...}` with an associated `\end{...}` until the command considered is fully processed, after which it goes back to normal (non-math) mode. Note that this has the disadvantage that any whole environment defined _inside_ of the special command will not be parsed as an environment, but rather as a series of TeX commands (I think it should be possible to reconstruct a complete env by parsing the content of the `\newcommand`, but I haven't tried it).