### PR TITLE
Added regex flags to `search_regex` method

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -601,10 +601,15 @@ class TexNode(object):
             self.expr.remove(child.expr),
             *nodes)
 
+    def search_regex(self, pattern, **kwargs):
+        r"""Find objects which match a regular expression.
 
-    def search_regex(self, pattern):
+        :param str pattern: The regular expression to search for
+        :param kwargs: any keyword arguments passed to ``re.finiter``
+        """
+
         for node in self.text:
-            for match in re.finditer(pattern, node):
+            for match in re.finditer(pattern, node, **kwargs):
                 body = match.group()  # group() returns the full match
                 start = match.start()
                 yield Token(body, node.position + start)


### PR DESCRIPTION
This PR adds the option to pass [regex flags](https://docs.python.org/3/library/re.html#flags) as a keyword argument to the `search_regex` method. I've also added a docstring to the same method to make the meaning of the `kwargs` argument clearer.