### PR TITLE
Fix missing `TexText` position

### DIFF
--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -1107,6 +1107,8 @@ class TexText(TexExpr, str):
     False
     >>> TexText('df ').strip()
     'df'
+    >>> TexText('df', position=0).position
+    0
     """
 
     _has_custom_contain = True

--- a/TexSoup/data.py
+++ b/TexSoup/data.py
@@ -1120,6 +1120,10 @@ class TexText(TexExpr, str):
         super().__init__('text', [text], position=position)
         self._text = text
 
+    def __new__(cls, text, position=-1):
+        '''Needed for instantiating with position info because we're subclassing `str` (which is probably not a good choice to begin with).'''
+        return super().__new__(cls, text)
+
     def __contains__(self, other):
         """
         >>> obj = TexText(Token('asdf'))

--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -125,7 +125,7 @@ def read_expr(src, skip_envs=(), tolerance=0, mode=MODE_NON_MATH):
         return read_arg(src, c, tolerance=tolerance)
 
     assert isinstance(c, Token)
-    return TexText(c)
+    return TexText(c, position=c.position)
 
 
 ################

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,6 +73,17 @@ def test_commands_envs_text():
     assert len(everything) == 12
 
 
+def test_position():
+    '''Tests that positions are correctly set.'''
+    s = '''0123   \n\\section{Test}\ns p a c e s \n\\cmd{Bye}{Bye}\n'''
+    soup = TexSoup(s)
+    positions = [n.position for n in soup.all]
+    print(positions)
+    print([s[i] for i in positions])
+    assert positions == [0, 8, 22, 36, 50]
+    assert [s[i] for i in positions] == ['0', '\\', '\n', '\\', '\n']
+
+
 #########
 # CASES #
 #########


### PR DESCRIPTION
This PR makes it so that the `position` field of `TexText` will be correctly filled.

Previously, for example
```python
TexSoup(r"""\section{FirstNode}
A text node""").all[1].position
```
would return `-1` for the position of the text node instead of the expected position `19`.
With this PR it will correctly return `19`. 
