### PR TITLE
[codex] make benchmark baselines grayscale

### DIFF
--- a/benchmarks/plot.py
+++ b/benchmarks/plot.py
@@ -35,7 +35,7 @@ BACKENDS = (
         'total': 50,
         'mean_ms': 829,
         'label': '829 ms',
-        'color': '#6e7c91',
+        'color': '#5f6368',
     },
     {
         'name': 'LaTeXML',
@@ -45,7 +45,7 @@ BACKENDS = (
         'total': 50,
         'mean_ms': 5231,
         'label': '5,231 ms',
-        'color': '#c06b3e',
+        'color': '#8b9096',
     },
 )
 

--- a/benchmarks/summary.svg
+++ b/benchmarks/summary.svg
@@ -40,8 +40,8 @@
 <defs>
 <pattern id="legend-timeout-pattern" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#7b8797" stroke-width="1.7" /></pattern>
 <pattern id="timeout-pattern-TexSoup" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#84b6a4" stroke-width="1.7" /></pattern>
-<pattern id="timeout-pattern-plasTeX" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#afb7c2" stroke-width="1.7" /></pattern>
-<pattern id="timeout-pattern-LaTeXML" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#dcae95" stroke-width="1.7" /></pattern>
+<pattern id="timeout-pattern-plasTeX" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#a7a9ac" stroke-width="1.7" /></pattern>
+<pattern id="timeout-pattern-LaTeXML" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="#bfc2c5" stroke-width="1.7" /></pattern>
 </defs>
 <rect x="0" y="0" width="980" height="360" rx="0" fill="var(--bg)" stroke="none" stroke-width="1" />
 <rect x="0.0" y="12" width="482.0" height="336" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
@@ -75,27 +75,27 @@
 <text x="144.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
 <clipPath id="clip-plasTeX"><rect x="223.0" y="114" width="74" height="182" rx="10" /></clipPath>
 <rect x="223.0" y="114" width="74" height="109.2" rx="0" fill="var(--segment-other-fill)" stroke="none" stroke-width="1" clip-path="url(#clip-plasTeX)" />
-<rect x="223.0" y="114" width="74" height="109.2" rx="0" fill="none" stroke="#d1d5dc" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-plasTeX)" />
+<rect x="223.0" y="114" width="74" height="109.2" rx="0" fill="none" stroke="#cccdcf" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-plasTeX)" />
 <text x="260.0" y="172.6" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">30</text>
 <rect x="223.0" y="223.2" width="74" height="32.76" rx="0" fill="var(--segment-timeout-fill)" stroke="none" stroke-width="1" clip-path="url(#clip-plasTeX)" />
 <rect x="223.0" y="223.2" width="74" height="32.76" rx="0" fill="url(#timeout-pattern-plasTeX)" stroke="none" stroke-width="1" clip-path="url(#clip-plasTeX)" />
-<rect x="223.0" y="223.2" width="74" height="32.76" rx="0" fill="none" stroke="#afb7c2" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-plasTeX)" />
+<rect x="223.0" y="223.2" width="74" height="32.76" rx="0" fill="none" stroke="#a7a9ac" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-plasTeX)" />
 <text x="260.0" y="243.57999999999998" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">9</text>
-<rect x="223.0" y="255.95999999999998" width="74" height="40.04" rx="0" fill="#6e7c91" stroke="none" stroke-width="1" clip-path="url(#clip-plasTeX)" />
+<rect x="223.0" y="255.95999999999998" width="74" height="40.04" rx="0" fill="#5f6368" stroke="none" stroke-width="1" clip-path="url(#clip-plasTeX)" />
 <text x="260.0" y="279.97999999999996" fill="#ffffff" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">11</text>
-<rect x="223.0" y="114" width="74" height="182" rx="10" fill="none" stroke="#6e7c91" stroke-width="1.5" />
+<rect x="223.0" y="114" width="74" height="182" rx="10" fill="none" stroke="#5f6368" stroke-width="1.5" />
 <text x="260.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">plasTeX</text>
 <clipPath id="clip-LaTeXML"><rect x="339.0" y="114" width="74" height="182" rx="10" /></clipPath>
 <rect x="339.0" y="114" width="74" height="25.480000000000004" rx="0" fill="var(--segment-other-fill)" stroke="none" stroke-width="1" clip-path="url(#clip-LaTeXML)" />
-<rect x="339.0" y="114" width="74" height="25.480000000000004" rx="0" fill="none" stroke="#ebd0c1" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-LaTeXML)" />
+<rect x="339.0" y="114" width="74" height="25.480000000000004" rx="0" fill="none" stroke="#dadbdd" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-LaTeXML)" />
 <text x="376.0" y="130.74" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">7</text>
 <rect x="339.0" y="139.48000000000002" width="74" height="50.96000000000001" rx="0" fill="var(--segment-timeout-fill)" stroke="none" stroke-width="1" clip-path="url(#clip-LaTeXML)" />
 <rect x="339.0" y="139.48000000000002" width="74" height="50.96000000000001" rx="0" fill="url(#timeout-pattern-LaTeXML)" stroke="none" stroke-width="1" clip-path="url(#clip-LaTeXML)" />
-<rect x="339.0" y="139.48000000000002" width="74" height="50.96000000000001" rx="0" fill="none" stroke="#dcae95" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-LaTeXML)" />
+<rect x="339.0" y="139.48000000000002" width="74" height="50.96000000000001" rx="0" fill="none" stroke="#bfc2c5" stroke-width="1.5" stroke-dasharray="6 4" clip-path="url(#clip-LaTeXML)" />
 <text x="376.0" y="168.96000000000004" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">14</text>
-<rect x="339.0" y="190.44000000000003" width="74" height="105.55999999999999" rx="0" fill="#c06b3e" stroke="none" stroke-width="1" clip-path="url(#clip-LaTeXML)" />
+<rect x="339.0" y="190.44000000000003" width="74" height="105.55999999999999" rx="0" fill="#8b9096" stroke="none" stroke-width="1" clip-path="url(#clip-LaTeXML)" />
 <text x="376.0" y="247.22000000000003" fill="#ffffff" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">29</text>
-<rect x="339.0" y="114" width="74" height="182" rx="10" fill="none" stroke="#c06b3e" stroke-width="1.5" />
+<rect x="339.0" y="114" width="74" height="182" rx="10" fill="none" stroke="#8b9096" stroke-width="1.5" />
 <text x="376.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">LaTeXML</text>
 <rect x="498.0" y="12" width="482.0" height="336" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
 <text x="516.0" y="40" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
@@ -113,10 +113,10 @@
 <rect x="605.0" y="273.5106666666667" width="74" height="22.489333333333335" rx="10" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="642.0" y="263.5106666666667" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">668 ms</text>
 <text x="642.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
-<rect x="721.0" y="268.0903333333333" width="74" height="27.909666666666666" rx="10" fill="#6e7c91" stroke="none" stroke-width="1" />
+<rect x="721.0" y="268.0903333333333" width="74" height="27.909666666666666" rx="10" fill="#5f6368" stroke="none" stroke-width="1" />
 <text x="758.0" y="258.0903333333333" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">829 ms</text>
 <text x="758.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">plasTeX</text>
-<rect x="837.0" y="119.88966666666667" width="74" height="176.11033333333333" rx="10" fill="#c06b3e" stroke="none" stroke-width="1" />
+<rect x="837.0" y="119.88966666666667" width="74" height="176.11033333333333" rx="10" fill="#8b9096" stroke="none" stroke-width="1" />
 <text x="874.0" y="109.88966666666667" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="600" text-anchor="middle">5,231 ms</text>
 <text x="874.0" y="316" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">LaTeXML</text>
 </svg>


### PR DESCRIPTION
## Summary
- change the benchmark plot palette so plasTeX and LaTeXML render in grayscale while TexSoup keeps the accent color
- regenerate `benchmarks/summary.svg`, which is embedded by both the root README and `benchmarks/README.md`

## Why
- make the benchmark graphic emphasize TexSoup without changing the underlying data or chart structure

## Validation
- `python3 benchmarks/plot.py`