### PR TITLE
Avoid crash when a known command's required arg ends a group

### DIFF
--- a/TexSoup/reader.py
+++ b/TexSoup/reader.py
@@ -603,7 +603,8 @@ def read_arg_required(
                 src, next(src), tolerance=tolerance, mode=mode))
             n_required -= 1
             continue
-        elif src.hasNext() and n_required > 0:
+        elif (src.hasNext() and n_required > 0
+                and src.peek().category not in (TC.GroupEnd, TC.BracketEnd)):
             next_token = next(src)
             if next_token.category == TC.Escape:
                 name, _ = read_command(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -778,3 +778,13 @@ def test_tabular_column_spec_raw():
     soup = TexSoup(r"$\begin{array}{l >{$}r<{$}} x & 1 \end{array}$")
     assert soup.array
     assert str(soup.array.args[0]) == r"{l >{$}r<{$}}"
+
+
+def test_known_command_missing_arg_at_group_end():
+    r"""A known command with a required arg should not crash when its argument
+    is absent because it ends a group. See Issue #189."""
+    soup = TexSoup(r"{\label}")
+    assert str(soup) == r"{\label}"
+
+    soup = TexSoup(r"\node[muxdemux] (north) at (3,3) {\label};")
+    assert soup.find('label') is not None


### PR DESCRIPTION
## Summary

- Fixes #189. `TexSoup(r"{\label}")` raised `TypeError: Malformed argument` because `\label` has a known one-required-argument signature, and when its argument is absent at the end of a group the parser consumed the closing `}` as the argument, leaving the group unterminated.
- `read_arg_required` now skips the fallback "use the next token as the argument" branch when that next token is a closing delimiter (`}` or `]`), so a missing required argument is simply left empty instead of swallowing the delimiter.

The reduced case is `{\label}`, but the same crash hit the original `\tikzmath{\label = 1;}` / `\node[...] {\label}` document in the issue.

## Validation

- `python3 -m pytest` (190 passed)
- New regression test `test_known_command_missing_arg_at_group_end` fails on the current parser and passes with this change.
